### PR TITLE
Install ChIPseeker on Test (second attempt)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -164,7 +164,7 @@ after_success:
   - echo "Pushing changes to repo ${REPO} on CVMFS Stratum 0 ${REPO_STRATUM0} as user ${REPO_USER}"
   - ssh ${REPO_USER}@${REPO_STRATUM0} cvmfs_server transaction ${REPO}
   - |
-    rsync -av /upper/ ${REPO_USER}@${REPO_STRATUM0}:/cvmfs/${REPO} || {
+    rsync -a /upper/ ${REPO_USER}@${REPO_STRATUM0}:/cvmfs/${REPO} || {
         echo "#### RSYNC FAILED, ABORTING TRANSACTION";
         ssh ${REPO_USER}@${REPO_STRATUM0} cvmfs_server abort -f ${REPO};
         travis_terminate 1;

--- a/test.galaxyproject.org/chipseeker.yml.lock
+++ b/test.galaxyproject.org/chipseeker.yml.lock
@@ -2,6 +2,7 @@ install_repository_dependencies: true
 install_resolver_dependencies: true
 install_tool_dependencies: false
 tool_panel_section_label: ChIP-seq
+install: 1
 tools:
 - name: chipseeker
   owner: rnateam


### PR DESCRIPTION
The first attempt failed when rsyncing changes to the stratum 0, because the Travis console log size grew too large and the build was terminated.