### PR TITLE
Tooling fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,14 @@ help:
 	@egrep '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[94m%-16s\033[0m %s\n", $$1, $$2}'
 
 lint: ## Lint all yaml files
-	find . -mindepth 2 -name '*.yml' | xargs -n 1 -P 8 python scripts/fix-lockfile.py
-	find . -mindepth 2 -name '*.yml' | xargs -n 1 -P 8 -I{} pykwalify -d '{}' -s .schema.yml
+	find ./$(TOOLSET) -name '*.yml' | grep '^\./[^/]*/' | xargs -n 1 -P 8 python scripts/fix-lockfile.py
+	find ./$(TOOLSET) -name '*.yml' | grep '^\./[^/]*/' | xargs -n 1 -P 8 -I{} pykwalify -d '{}' -s .schema.yml
 
 fix: ## Fix all lockfiles and add any missing revisions
 	@# Generates the lockfile or updates it if it is missing tools
-	find . -mindepth 2 -name '*.yml' | xargs -n 1 -P 8 python scripts/fix-lockfile.py
+	find ./$(TOOLSET) -name '*.yml' | grep '^\./[^/]*/' | xargs -n 1 -P 8 python scripts/fix-lockfile.py
 	@# --without says only add those hashes for those missing hashes (zB new tools)
-	find . -mindepth 2 -name '*.yml' | xargs -n 1 -P 8 python scripts/update-tool.py --without
+	find ./$(TOOLSET) -name '*.yml' | grep '^\./[^/]*/' | xargs -n 1 -P 8 python scripts/update-tool.py --without
 
 #install:
 	#@echo "Installing any updated versions of $<"
@@ -21,7 +21,7 @@ fix: ## Fix all lockfiles and add any missing revisions
 
 update-trusted: ## Run the update script
 	@# Missing --without, so this updates all tools in the file.
-	find . -mindepth 2 -name '*.yml' | xargs -n 1 -P 8 python scripts/update-tool.py --owner iuc --owner earlhaminst --owner rnateam
+	find ./$(TOOLSET) -name '*.yml' | grep '^\./[^/]*/' | xargs -n 1 -P 8 python scripts/update-tool.py --owner iuc --owner earlhaminst --owner rnateam
 
 
 .PHONY: lint update-trusted help fix

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - `yaml` files are manually curated
 - `yaml.lock` files are automatically generated
 - Only IUC tools are automatically updated with the latest version each week
+- Use the provided `requirements.txt` to install dependences needed for the make targets
 
 ### Updating an Existing Tool
 
@@ -22,3 +23,16 @@
 	- Run `make fix`
 	- Edit the .yaml.lock to correct the version number.
 - Open a pull request
+
+### Tips
+
+Use `make TOOLSET=<toolset_dir> <target>` to limit a make action to a specific toolset subdirectory, e.g.:
+
+```console
+$ make TOOLSET=usegalaxy.org lint
+find ./usegalaxy.org -name '*.yml' | grep '^\./[^/]*/' | xargs -n 1 -P 8 python scripts/fix-lockfile.py
+find ./usegalaxy.org -name '*.yml' | grep '^\./[^/]*/' | xargs -n 1 -P 8 -I{} pykwalify -d '{}' -s .schema.yml
+ INFO - validation.valid
+ INFO - validation.valid
+ ...
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 bioblend==0.10.0
 ephemeris==0.8.0
-pykwalify==1.6.0
+pykwalify>=1.6.1
 PyYAML>=4.2b1

--- a/scripts/fix-lockfile.py
+++ b/scripts/fix-lockfile.py
@@ -12,11 +12,11 @@ ts = toolshed.ToolShedInstance(url='https://toolshed.g2.bx.psu.edu')
 
 def update_file(fn):
     with open(fn, 'r') as handle:
-        unlocked = yaml.load(handle)
+        unlocked = yaml.safe_load(handle)
     # If a lock file exists, load it from that file
     if os.path.exists(fn + '.lock'):
         with open(fn + '.lock', 'r') as handle:
-            locked = yaml.load(handle)
+            locked = yaml.safe_load(handle)
     else:
         # Otherwise just clone the "unlocked" list.
         locked = copy.deepcopy(unlocked)

--- a/scripts/fix-lockfile.py
+++ b/scripts/fix-lockfile.py
@@ -59,7 +59,7 @@ def update_file(fn):
     clean_lockfile.update({
         "install_repository_dependencies": True,
         "install_resolver_dependencies": True,
-        "install_tool_dependencies": True,
+        "install_tool_dependencies": False,     # These are TS deps, not Conda
     })
 
     with open(fn + '.lock', 'w') as handle:

--- a/scripts/update-tool.py
+++ b/scripts/update-tool.py
@@ -9,7 +9,7 @@ ts = toolshed.ToolShedInstance(url='https://toolshed.g2.bx.psu.edu')
 
 def update_file(fn, owner=None, name=None, without=False):
     with open(fn + '.lock', 'r') as handle:
-        locked = yaml.load(handle)
+        locked = yaml.safe_load(handle)
 
     # Update any locked tools.
     for tool in locked['tools']:


### PR DESCRIPTION
- Support using make targets with a subset of tool definitions with `make TOOLSET=<toolshed_dir> <target>`
- Use `yaml.safe_load()` instead of `yaml.load()`
- Disable installation of TS dependencies by default