### PR TITLE
Update label id for chipseeker to match others

### DIFF
--- a/usegalaxy.org/chipseeker.yml
+++ b/usegalaxy.org/chipseeker.yml
@@ -1,4 +1,4 @@
-tool_panel_section_id: chip_seq
+tool_panel_section_label: chip_seq
 tools:
   - name: chipseeker
     owner: rnateam

--- a/usegalaxy.org/chipseeker.yml.lock
+++ b/usegalaxy.org/chipseeker.yml.lock
@@ -1,10 +1,10 @@
 install_repository_dependencies: true
 install_resolver_dependencies: true
 install_tool_dependencies: false
-tool_panel_section_id: chip_seq
+tool_panel_section_label: chip_seq
 tools:
 - name: chipseeker
   owner: rnateam
   revisions:
   - 1b9a9409831d
-  tool_panel_section_id: chip_seq
+  tool_panel_section_label: chip_seq


### PR DESCRIPTION
Otherwise, getting the following error:
```
$ make TOOLSET=usegalaxy.org lint
find ./usegalaxy.org -name '*.yml' | grep '^\./[^/]*/' | xargs -n 1 -P 8 python scripts/fix-lockfile.py
tool: {'owner': 'rnateam', 'name': 'chipseeker'}; unlocked: {'tool_panel_section_id': 'chip_seq', 'tools': [{'owner': 'rnateam', 'name': 'chipseeker'}]}
Traceback (most recent call last):
  File "scripts/fix-lockfile.py", line 77, in <module>
    update_file(args.fn.name)
  File "scripts/fix-lockfile.py", line 58, in update_file
    raise e
KeyError: 'tool_panel_section_label'
make: *** [lint] Error 1
```