### PR TITLE
add snpeff download 4.1.0

### DIFF
--- a/test.galaxyproject.org/snpeff.yml
+++ b/test.galaxyproject.org/snpeff.yml
@@ -1,0 +1,4 @@
+tool_panel_section_id: variant_calling
+tools:
+    - name: snpeff
+    - owner: iuc

--- a/test.galaxyproject.org/snpeff.yml.lock
+++ b/test.galaxyproject.org/snpeff.yml.lock
@@ -3,7 +3,7 @@ install_resolver_dependencies: true
 install_tool_dependencies: false
 tool_panel_section_id: variant_calling
 tools:
-- name: snpEff_download
+- name: snpeff
   owner: iuc
   revisions:
   - 20f0429a4bfe

--- a/test.galaxyproject.org/snpeff.yml.lock
+++ b/test.galaxyproject.org/snpeff.yml.lock
@@ -1,0 +1,10 @@
+install_repository_dependencies: false
+install_resolver_dependencies: true
+install_tool_dependencies: false
+tool_panel_section_id: variant_calling
+tools:
+- name: snpEff_download
+  owner: iuc
+  revisions:
+  - 20f0429a4bfe
+  tool_panel_section_id: variant_calling


### PR DESCRIPTION
manually created files atm since `make fix` creates https://github.com/galaxyproject/usegalaxy-tools/pull/30 but does not create the lock file for me.