### PR TITLE
Move Prokka from Assembly to Annotation

### DIFF
--- a/common_toolset/annotation.yml
+++ b/common_toolset/annotation.yml
@@ -4,3 +4,5 @@ tools:
   owner: iuc
 - name: abricate
   owner: iuc
+- name: prokka
+  owner: crs4

--- a/common_toolset/annotation.yml.lock
+++ b/common_toolset/annotation.yml.lock
@@ -12,3 +12,8 @@ tools:
   revisions:
   - 78c75f134c16
   tool_panel_section_label: Annotation
+- name: prokka
+  owner: crs4
+  revisions:
+  - a17498c603ec
+  tool_panel_section_label: Annotation

--- a/common_toolset/assembly.yml
+++ b/common_toolset/assembly.yml
@@ -1,7 +1,5 @@
 tool_panel_section_label: Assembly
 tools:
-- name: prokka
-  owner: crs4
 - name: quast
   owner: iuc
 - name: unicycler

--- a/common_toolset/assembly.yml.lock
+++ b/common_toolset/assembly.yml.lock
@@ -2,11 +2,6 @@ install_repository_dependencies: true
 install_resolver_dependencies: true
 install_tool_dependencies: false
 tools:
-- name: prokka
-  owner: crs4
-  revisions:
-  - a17498c603ec
-  tool_panel_section_label: Assembly
 - name: quast
   owner: iuc
   revisions:


### PR DESCRIPTION
I think Prokka was put in Assembly section by mistake as it's in Annotation section on all usegalaxy.*