### PR TITLE
Fix incorrect YAML in compose_text_param.yml

### DIFF
--- a/usegalaxy.org/compose_text_param.yml
+++ b/usegalaxy.org/compose_text_param.yml
@@ -1,4 +1,4 @@
 tool_panel_section_id: expression_tools
 tools:
   - name: compose_text_param
-  - owner: iuc
+    owner: iuc


### PR DESCRIPTION
This was breaking `make TOOLSET=usegalaxy.org lint` on my system, not sure how it was working for anyone else.

```
{py27}dave@gaius:~/github-repos/usegalaxy-tools $ make TOOLSET=usegalaxy.org lint
find ./usegalaxy.org -name '*.yml' | grep '^\./[^/]*/' | xargs -n 1 -P 8 python scripts/fix-lockfile.py
Traceback (most recent call last):
  File "scripts/fix-lockfile.py", line 97, in <module>
    update_file(args.fn.name)
  File "scripts/fix-lockfile.py", line 40, in update_file
    locked_tools = [x for x in locked['tools'] if x['name'] == tool['name'] and x['owner'] == tool['owner']]
KeyError: 'owner'
make: *** [Makefile:8: lint] Error 123
```
