### PR TITLE
Allow for the use of `tool_shed_url` in tool YAMLs

### DIFF
--- a/.schema.yml
+++ b/.schema.yml
@@ -18,3 +18,6 @@ mapping:
                 "owner":
                     type: str
                     required: true
+                "tool_shed_url":
+                    type: str
+                    required: false

--- a/scripts/fix-lockfile.py
+++ b/scripts/fix-lockfile.py
@@ -5,10 +5,7 @@ import argparse
 import logging
 import string
 
-from bioblend import toolshed
-
 logging.basicConfig()
-ts = toolshed.ToolShedInstance(url='https://toolshed.g2.bx.psu.edu')
 
 
 def section_id_chr(c):
@@ -60,6 +57,11 @@ def update_file(fn):
             'owner': tool['owner'],
             'revisions': sorted(list(set(revisions))),  # Cast to list for yaml serialization
         }
+
+        if 'tool_shed_url' in tool:
+            ts_url = tool['tool_shed_url']
+            logging.warning('Non-default Tool Shed URL for %s/%s: %s', tool['owner'], tool['name'], ts_url)
+            new_tool['tool_shed_url'] = ts_url
 
         # Set the section - id supercedes label/name
         if 'tool_panel_section_id' in unlocked:


### PR DESCRIPTION
We have a no-TTS-in-production rule for usegalaxy.org, but do occasionally install from the TTS on test.galaxyproject.org. This will emit warnings if you specify a non-MTS TS URL, but removes the assumed/forced MTS.