### PR TITLE
Duplex Analysis: Add to test.galaxyproject.org (attempt 3).

### DIFF
--- a/test.galaxyproject.org/du_novo.yml
+++ b/test.galaxyproject.org/du_novo.yml
@@ -6,3 +6,7 @@ tools:
   owner: nick
 - name: sequence_content_trimmer
   owner: nick
+- name: duplex_family_size_distribution
+  owner: iuc
+- name: variant_analyzer
+  owner: iuc

--- a/test.galaxyproject.org/du_novo.yml.lock
+++ b/test.galaxyproject.org/du_novo.yml.lock
@@ -21,3 +21,15 @@ tools:
   - 7f170cb06e2e
   tool_panel_section_id: du_novo
   tool_panel_section_label: Du Novo
+- name: duplex_family_size_distribution
+  owner: iuc
+  revisions:
+  - 7fc3c8704c05
+  tool_panel_section_id: du_novo
+  tool_panel_section_label: Du Novo
+- name: variant_analyzer
+  owner: iuc
+  revisions:
+  - 8d29173d49a9
+  tool_panel_section_id: du_novo
+  tool_panel_section_label: Du Novo


### PR DESCRIPTION
Okay, I think I got it this time. I've added these tools to the existing `du_novo.yaml` file, and included the `.lock`.
- Attempt 1: #88
- Attempt 2: #89

---

These are a soon-to-be-published set of tools from Irene Tiemann-Boege's group at JKU.

They can be used to check the quality of duplex sequencing runs and find variants with more sensitivity than the standard analysis.