### PR TITLE
Update HyPhy tools on test again

### DIFF
--- a/test.galaxyproject.org/hyphy_tools.yml.lock
+++ b/test.galaxyproject.org/hyphy_tools.yml.lock
@@ -6,66 +6,66 @@ tools:
 - name: hyphy_absrel
   owner: iuc
   revisions:
-  - 5c87e4907e08
+  - de93e1fbdc31
   tool_panel_section_id: hyphy_methods
   tool_panel_section_label: HyPhy Methods
 - name: hyphy_bgm
   owner: iuc
   revisions:
-  - bf97cacc1a55
+  - cdfa1afd7cb0
   tool_panel_section_id: hyphy_methods
   tool_panel_section_label: HyPhy Methods
 - name: hyphy_busted
   owner: iuc
   revisions:
-  - b678fe748dc5
+  - f8d88dcef64e
   tool_panel_section_id: hyphy_methods
   tool_panel_section_label: HyPhy Methods
 - name: hyphy_fade
   owner: iuc
   revisions:
-  - 6164d9298db9
+  - da4192d32e10
   tool_panel_section_id: hyphy_methods
   tool_panel_section_label: HyPhy Methods
 - name: hyphy_fel
   owner: iuc
   revisions:
-  - 6c3ece5fb602
+  - a8b34daec0d9
   tool_panel_section_id: hyphy_methods
   tool_panel_section_label: HyPhy Methods
 - name: hyphy_fubar
   owner: iuc
   revisions:
-  - 0f108ee932ea
+  - 6943fbec145c
   tool_panel_section_id: hyphy_methods
   tool_panel_section_label: HyPhy Methods
 - name: hyphy_gard
   owner: iuc
   revisions:
-  - 1942d02039c2
+  - a03d87763f51
   tool_panel_section_id: hyphy_methods
   tool_panel_section_label: HyPhy Methods
 - name: hyphy_meme
   owner: iuc
   revisions:
-  - 7b3f9c78cf6d
+  - d02c8e6f7f2a
   tool_panel_section_id: hyphy_methods
   tool_panel_section_label: HyPhy Methods
 - name: hyphy_relax
   owner: iuc
   revisions:
-  - 551616a65f8f
+  - 1da578d6a253
   tool_panel_section_id: hyphy_methods
   tool_panel_section_label: HyPhy Methods
 - name: hyphy_slac
   owner: iuc
   revisions:
-  - c2bed8cc8fc1
+  - a603e2f909e5
   tool_panel_section_id: hyphy_methods
   tool_panel_section_label: HyPhy Methods
 - name: hyphy_sm19
   owner: iuc
   revisions:
-  - ae7c42d49717
+  - d2acd8d86e55
   tool_panel_section_id: hyphy_methods
   tool_panel_section_label: HyPhy Methods


### PR DESCRIPTION
The previous time this was PR'd, travis had failed to update the toolshed with the new versions. This is no longer the case.