### PR TITLE
Remove suite, install tn93, add tn93_readreduce.

### DIFF
--- a/usegalaxy.org/evolution.yml
+++ b/usegalaxy.org/evolution.yml
@@ -4,5 +4,7 @@ tools:
   owner: iuc
 - name: iqtree
   owner: iuc
-- name: suite_tn93
+- name: tn93
+  owner: iuc
+- name: tn93_readreduce
   owner: iuc

--- a/usegalaxy.org/evolution.yml.lock
+++ b/usegalaxy.org/evolution.yml.lock
@@ -16,9 +16,15 @@ tools:
   - 973a28be3b7f
   tool_panel_section_id: evolution
   tool_panel_section_label: Evolution
-- name: suite_tn93
+- name: tn93
   owner: iuc
   revisions:
-  - 4f89354ffb6e
+  - ccebde0e2d61
+  tool_panel_section_id: evolution
+  tool_panel_section_label: Evolution
+- name: tn93_readreduce
+  owner: iuc
+  revisions:
+  - bdaadfd0c843
   tool_panel_section_id: evolution
   tool_panel_section_label: Evolution


### PR DESCRIPTION
The automated installer prematurely shut down the docker container, so the install database on cvmfs had `tn93` stuck at the cloning stage. I reset the state manually, so this _should_ install correctly. This also adds `tn93_readreduce` to the yaml and lock file, since that repository managed to install before the docker container shut down.