### PR TITLE
Update Variant Annotator to Python 3 version (2nd try)

### DIFF
--- a/test.galaxyproject.org/variant_calling.yml.lock
+++ b/test.galaxyproject.org/variant_calling.yml.lock
@@ -87,6 +87,7 @@ tools:
   owner: nick
   revisions:
   - 411adeff1eec
+  - 7f19e8c03358
   tool_panel_section_id: variant_calling
   tool_panel_section_label: Variant Calling
 - name: freebayes


### PR DESCRIPTION
This is a followup to #169 after I corrected issues in the tool pointed out by @mvdbeek.

I went ahead and made a new branch & PR to keep the commits simple.

This updates Variant Annotator on test.galaxyproject.org.