### PR TITLE
Variant Annotator: Fix bug in previous update.

### DIFF
--- a/test.galaxyproject.org/variant_calling.yml.lock
+++ b/test.galaxyproject.org/variant_calling.yml.lock
@@ -88,6 +88,7 @@ tools:
   revisions:
   - 411adeff1eec
   - 7f19e8c03358
+  - cf2af5c3118c
   tool_panel_section_id: variant_calling
   tool_panel_section_label: Variant Calling
 - name: freebayes


### PR DESCRIPTION
I fixed a bug in the tool xml that I didn't catch last time (#173) until it was deployed to test.