### PR TITLE
Update Variant Annotator to Python 3 version on Main.

### DIFF
--- a/usegalaxy.org/variant_calling.yml.lock
+++ b/usegalaxy.org/variant_calling.yml.lock
@@ -51,6 +51,7 @@ tools:
   owner: nick
   revisions:
   - 411adeff1eec
+  - cf2af5c3118c
   tool_panel_section_id: variant_calling
   tool_panel_section_label: Variant Calling
 - name: phylorelatives


### PR DESCRIPTION
After testing on test.galaxyproject.org (#174), this version looks ready to be pushed out to Main.