### PR TITLE
Update tool installer container to use 20.09 initial freeze image

### DIFF
--- a/.ci/jenkins.sh
+++ b/.ci/jenkins.sh
@@ -10,7 +10,7 @@ GALAXY_URL="http://127.0.0.1:${LOCAL_PORT}"
 SSH_MASTER_SOCKET_DIR="${HOME}/.cache/usegalaxy-tools"
 
 # Set to 'centos:7' and set GALAXY_GIT_* below to use a clone
-GALAXY_DOCKER_IMAGE='galaxy/galaxy-k8s:20.05'
+GALAXY_DOCKER_IMAGE='galaxy/galaxy-k8s:20.09'
 # Disable if using a locally built image e.g. for debugging
 GALAXY_DOCKER_IMAGE_PULL=true
 


### PR DESCRIPTION
Updates to use https://hub.docker.com/layers/galaxy/galaxy-k8s/20.09/images/sha256-f607f66d7af6e568661e4f63d96cdeea8f5e5d655eb9873b5492dc64eae61ec0?context=explore