### PR TITLE
Add hhsearch, springsuite and splitfasta to usegalaxy.org

### DIFF
--- a/test.galaxyproject.org/protein_modeling.yml.lock
+++ b/test.galaxyproject.org/protein_modeling.yml.lock
@@ -7,7 +7,6 @@ tools:
   owner: guerler
   revisions:
   - 3e4d88784254
-  - cec2aa4d6c0d
   tool_panel_section_id: protein_modeling
   tool_panel_section_label: Protein Modeling
 - name: springsuite
@@ -15,8 +14,6 @@ tools:
   revisions:
   - 0ea00dce62ab
   - 860bd6f8f480
-  - b53a98b90354
   - f8ba4dd48cbd
-  - 4a4888bf0338
   tool_panel_section_id: protein_modeling
   tool_panel_section_label: Protein Modeling

--- a/test.galaxyproject.org/protein_modeling.yml.lock
+++ b/test.galaxyproject.org/protein_modeling.yml.lock
@@ -17,5 +17,6 @@ tools:
   - 860bd6f8f480
   - b53a98b90354
   - f8ba4dd48cbd
+  - 4a4888bf0338
   tool_panel_section_id: protein_modeling
   tool_panel_section_label: Protein Modeling

--- a/usegalaxy.org/fasta_fastq.yml
+++ b/usegalaxy.org/fasta_fastq.yml
@@ -80,3 +80,5 @@ tools:
   owner: iuc
 - name: umi_tools_count
   owner: iuc
+- name: splitfasta
+  owner: rnateam

--- a/usegalaxy.org/fasta_fastq.yml.lock
+++ b/usegalaxy.org/fasta_fastq.yml.lock
@@ -278,3 +278,9 @@ tools:
   - 276b4111b253
   tool_panel_section_id: fasta_fastq
   tool_panel_section_label: FASTA/FASTQ
+- name: splitfasta
+  owner: rnateam
+  revisions:
+  - 733ca84b21ee
+  tool_panel_section_id: fasta_fastq
+  tool_panel_section_label: FASTA/FASTQ

--- a/usegalaxy.org/protein_modeling.yml
+++ b/usegalaxy.org/protein_modeling.yml
@@ -1,0 +1,6 @@
+tool_panel_section_label: Protein Modeling
+tools:
+- name: hhsuite
+  owner: guerler
+- name: springsuite
+  owner: guerler

--- a/usegalaxy.org/protein_modeling.yml.lock
+++ b/usegalaxy.org/protein_modeling.yml.lock
@@ -6,16 +6,12 @@ tools:
 - name: hhsuite
   owner: guerler
   revisions:
-  - 3e4d88784254
   - cec2aa4d6c0d
   tool_panel_section_id: protein_modeling
   tool_panel_section_label: Protein Modeling
 - name: springsuite
   owner: guerler
   revisions:
-  - 0ea00dce62ab
-  - 860bd6f8f480
   - b53a98b90354
-  - f8ba4dd48cbd
   tool_panel_section_id: protein_modeling
   tool_panel_section_label: Protein Modeling

--- a/usegalaxy.org/protein_modeling.yml.lock
+++ b/usegalaxy.org/protein_modeling.yml.lock
@@ -12,6 +12,6 @@ tools:
 - name: springsuite
   owner: guerler
   revisions:
-  - b53a98b90354
+  - 4a4888bf0338
   tool_panel_section_id: protein_modeling
   tool_panel_section_label: Protein Modeling


### PR DESCRIPTION
PR requests to add three tools to main. `hhsearch`, `springsuite` (containing min-Z), and `splitfasta`. Tools are required for protein interaction prediction pipeline.