### PR TITLE
Install CustomProDB data manager on test.galaxyproject.org

### DIFF
--- a/test.galaxyproject.org/data_managers.yml
+++ b/test.galaxyproject.org/data_managers.yml
@@ -46,3 +46,5 @@ tools:
   owner: iuc
 - name: data_manager_gemini_database_downloader
   owner: iuc
+- name: custom_pro_db_annotation_data_manager
+  owner: galaxyp

--- a/test.galaxyproject.org/data_managers.yml.lock
+++ b/test.galaxyproject.org/data_managers.yml.lock
@@ -141,3 +141,9 @@ tools:
   - f57426daa04d
   tool_panel_section_id: data_managers
   tool_panel_section_label: Data Managers
+- name: custom_pro_db_annotation_data_manager
+  owner: galaxyp
+  revisions:
+  - 9ee512decde8
+  tool_panel_section_id: data_managers
+  tool_panel_section_label: Data Managers


### PR DESCRIPTION
Generates reference data used in tutorials for smörgåsbord.