### PR TITLE
Install a version of peptideshaker corresponding to search_gui 3.3.10.1

### DIFF
--- a/usegalaxy.org/proteomics.yml.lock
+++ b/usegalaxy.org/proteomics.yml.lock
@@ -6,9 +6,7 @@ tools:
 - name: peptideshaker
   owner: galaxyp
   revisions:
-  - 3634c90301af
-  - f35bb9d0c93e
-  - 1beff3ddce58
+  - 864bd76db767
   tool_panel_section_id: proteomics
   tool_panel_section_label: Proteomics
 - name: custom_pro_db


### PR DESCRIPTION
Per @jmchilton "that would seem to be the best candidate" for the current tutorial. I'll also manually hide the 4.0.x version that's installed for now if this works.