### PR TITLE
Slightly upgrade peptideshaker on usegalaxy.org

### DIFF
--- a/usegalaxy.org/proteomics.yml.lock
+++ b/usegalaxy.org/proteomics.yml.lock
@@ -6,7 +6,10 @@ tools:
 - name: peptideshaker
   owner: galaxyp
   revisions:
-  - 864bd76db767
+  - 3634c90301af
+  - f35bb9d0c93e
+  - 7fdd9119cc4f
+  - 1beff3ddce58
   tool_panel_section_id: proteomics
   tool_panel_section_label: Proteomics
 - name: custom_pro_db


### PR DESCRIPTION
I also added the old versions that were listed back because I probably should not have removed them in the first place. `7fdd9119cc4f` includes the wrapper syntax fixes in galaxyproteomics/tools-galaxyp#419 but is before the major version change. I also removed `864bd76db767` and will remove this from usegalaxy.org manually since that version will never be runnable without manually fixing the wrapper.