### PR TITLE
Update bealign to 0.20.1 on usegalaxy.org

### DIFF
--- a/usegalaxy.org/mapping.yml.lock
+++ b/usegalaxy.org/mapping.yml.lock
@@ -6,6 +6,7 @@ tools:
 - name: bioext_bealign
   owner: iuc
   revisions:
+  - d8b6f0adaa79
   - f9b72a376ec9
   tool_panel_section_id: mapping
   tool_panel_section_label: Mapping


### PR DESCRIPTION
This update includes built-in reference sequences for SARS-CoV-2 genes.