### PR TITLE
Update duplex_family_size_distribution on test.org

### DIFF
--- a/test.galaxyproject.org/du_novo.yml.lock
+++ b/test.galaxyproject.org/du_novo.yml.lock
@@ -1,5 +1,5 @@
-install_repository_dependencies: true
-install_resolver_dependencies: true
+install_repository_dependencies: false
+install_resolver_dependencies: false
 install_tool_dependencies: false
 tool_panel_section_label: Du Novo
 tools:

--- a/test.galaxyproject.org/du_novo.yml.lock
+++ b/test.galaxyproject.org/du_novo.yml.lock
@@ -24,7 +24,7 @@ tools:
 - name: duplex_family_size_distribution
   owner: iuc
   revisions:
-  - 7fc3c8704c05
+  - ec5a92514113
   tool_panel_section_id: du_novo
   tool_panel_section_label: Du Novo
 - name: variant_analyzer


### PR DESCRIPTION
Old version is Python 2.7 and does not have deps in biocontainers.