### PR TITLE
Prevent old non-working versin of regex_find_replace from being reinstalled

### DIFF
--- a/usegalaxy.org/text_manipulation.yml.lock
+++ b/usegalaxy.org/text_manipulation.yml.lock
@@ -106,7 +106,6 @@ tools:
 - name: regex_find_replace
   owner: galaxyp
   revisions:
-  - 209b7c5ee9d7
   - ae8c4b2488e7
   tool_panel_section_id: text_manipulation
   tool_panel_section_label: Text Manipulation


### PR DESCRIPTION
Note you can't actually uninstall tools using this repo, I uninstalled the tools manually, this would just prevent them from being reinstalled on a future PR.