### PR TITLE
Remove sam_merge (sam_merge2 tool) from usegalaxy.org

### DIFF
--- a/usegalaxy.org/sam_bam.yml
+++ b/usegalaxy.org/sam_bam.yml
@@ -30,8 +30,6 @@ tools:
   owner: devteam
 - name: filter_on_md
   owner: boris
-- name: sam_merge
-  owner: devteam
 - name: pileup_interval
   owner: devteam
 - name: pileup_parser

--- a/usegalaxy.org/sam_bam.yml.lock
+++ b/usegalaxy.org/sam_bam.yml.lock
@@ -99,12 +99,6 @@ tools:
   - ac70bfaf1224
   tool_panel_section_id: sam_bam
   tool_panel_section_label: SAM/BAM
-- name: sam_merge
-  owner: devteam
-  revisions:
-  - 1977f1637890
-  tool_panel_section_id: sam_bam
-  tool_panel_section_label: SAM/BAM
 - name: pileup_interval
   owner: devteam
   revisions:


### PR DESCRIPTION
This tool is broken and has not been updated in 6 years, there are alternatives.