### PR TITLE
Update Galaxy image version to 21.05

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,7 @@
 # usegalaxy.* admins own everything
-*                           @galaxyproject/universe-admins
+#*                           @galaxyproject/universe-admins
+# Disable the above for now until such time as non-.org admins use this
+*                           @galaxyproject/tool-installers
 
 # Galaxy Project AU servers
 #usegalaxy.org.au*           @usegalaxy-au/...

--- a/test.galaxyproject.org/chip_seq.yml.lock
+++ b/test.galaxyproject.org/chip_seq.yml.lock
@@ -1,5 +1,5 @@
-install_repository_dependencies: true
-install_resolver_dependencies: true
+install_repository_dependencies: false
+install_resolver_dependencies: false
 install_tool_dependencies: false
 tool_panel_section_label: ChIP-seq
 tools:
@@ -13,12 +13,14 @@ tools:
   owner: iuc
   revisions:
   - d3ebbf39b1c5
+  - de7795890bc5
   tool_panel_section_id: chip_seq
   tool_panel_section_label: ChIP-seq
 - name: macs2
   owner: iuc
   revisions:
   - 644444825ef9
+  - 1ac88e46ee0f
   tool_panel_section_id: chip_seq
   tool_panel_section_label: ChIP-seq
   tool_shed_url: testtoolshed.g2.bx.psu.edu
@@ -32,6 +34,7 @@ tools:
   owner: iuc
   revisions:
   - 2365720de36d
+  - 79f505a25bb8
   tool_panel_section_id: chip_seq
   tool_panel_section_label: ChIP-seq
 - name: cwpair2


### PR DESCRIPTION
Also:

- Drop non-org team from Codeowners so we don't annoy them since only .org is using this repo currently.
- Update Chip-SEQ section on test.org to test the version change.