### PR TITLE
Install tools for computational chemistry IWC workflows

### DIFF
--- a/usegalaxy.org/chemicaltoolbox.yml
+++ b/usegalaxy.org/chemicaltoolbox.yml
@@ -1,11 +1,28 @@
 tool_panel_section_label: ChemicalToolBox
-
 tools:
 - name: chemical_data_sources
   owner: bgruening
 - name: chemfp
   owner: bgruening
 - name: get_pdb
+  owner: bgruening
+- name: rdock_rbdock
+  owner: bgruening
+- name: rdock_rbcavity
+  owner: bgruening
+- name: rdock_sort_filter
+  owner: bgruening
+- name: sucos_docking_scoring
+  owner: bgruening
+- name: ctb_frankenstein_ligand
+  owner: bgruening
+- name: enumerate_charges
+  owner: bgruening
+- name: ctb_rdkit_descriptors
+  owner: bgruening
+- name: openbabel_compound_convert
+  owner: bgruening
+- name: get_online_data
   owner: bgruening
 - name: gmx_setup
   owner: chemteam
@@ -16,4 +33,20 @@ tools:
 - name: gmx_em
   owner: chemteam
 - name: gmx_sim
+  owner: chemteam
+- name: gmx_makendx
+  owner: chemteam
+- name: gmx_merge_topology_files
+  owner: chemteam
+- name: parmconv
+  owner: chemteam
+- name: md_converter
+  owner: chemteam
+- name: ambertools_acpype
+  owner: chemteam
+- name: biomd_neqgamma
+  owner: chemteam
+- name: ambertools_antechamber
+  owner: chemteam
+- name: mmpbsa_mmgbsa
   owner: chemteam

--- a/usegalaxy.org/chemicaltoolbox.yml
+++ b/usegalaxy.org/chemicaltoolbox.yml
@@ -6,9 +6,9 @@ tools:
   owner: bgruening
 - name: get_pdb
   owner: bgruening
-- name: rdock_rbdock
+- name: rxdock_rbdock
   owner: bgruening
-- name: rdock_rbcavity
+- name: rxdock_rbcavity
   owner: bgruening
 - name: rdock_sort_filter
   owner: bgruening

--- a/usegalaxy.org/chemicaltoolbox.yml.lock
+++ b/usegalaxy.org/chemicaltoolbox.yml.lock
@@ -21,6 +21,60 @@ tools:
   - 538790c6c21b
   tool_panel_section_id: chemicaltoolbox
   tool_panel_section_label: ChemicalToolBox
+- name: rdock_rbdock
+  owner: bgruening
+  revisions:
+  - c362398df83b
+  tool_panel_section_id: chemicaltoolbox
+  tool_panel_section_label: ChemicalToolBox
+- name: rdock_rbcavity
+  owner: bgruening
+  revisions:
+  - 7e5c2e4bc227
+  tool_panel_section_id: chemicaltoolbox
+  tool_panel_section_label: ChemicalToolBox
+- name: rdock_sort_filter
+  owner: bgruening
+  revisions:
+  - d1ca4b45f615
+  tool_panel_section_id: chemicaltoolbox
+  tool_panel_section_label: ChemicalToolBox
+- name: sucos_docking_scoring
+  owner: bgruening
+  revisions:
+  - 4f1896782f7c
+  tool_panel_section_id: chemicaltoolbox
+  tool_panel_section_label: ChemicalToolBox
+- name: ctb_frankenstein_ligand
+  owner: bgruening
+  revisions:
+  - 7255688c77f3
+  tool_panel_section_id: chemicaltoolbox
+  tool_panel_section_label: ChemicalToolBox
+- name: enumerate_charges
+  owner: bgruening
+  revisions:
+  - bbbf5fb356dd
+  tool_panel_section_id: chemicaltoolbox
+  tool_panel_section_label: ChemicalToolBox
+- name: ctb_rdkit_descriptors
+  owner: bgruening
+  revisions:
+  - a1c53f0533b0
+  tool_panel_section_id: chemicaltoolbox
+  tool_panel_section_label: ChemicalToolBox
+- name: openbabel_compound_convert
+  owner: bgruening
+  revisions:
+  - e2c36f62e22f
+  tool_panel_section_id: chemicaltoolbox
+  tool_panel_section_label: ChemicalToolBox
+- name: get_online_data
+  owner: bgruening
+  revisions:
+  - 2538366eb8fb
+  tool_panel_section_id: chemicaltoolbox
+  tool_panel_section_label: ChemicalToolBox
 - name: gmx_setup
   owner: chemteam
   revisions:
@@ -49,5 +103,53 @@ tools:
   owner: chemteam
   revisions:
   - a97dcfc23b4b
+  tool_panel_section_id: chemicaltoolbox
+  tool_panel_section_label: ChemicalToolBox
+- name: gmx_makendx
+  owner: chemteam
+  revisions:
+  - 5f9f51642a24
+  tool_panel_section_id: chemicaltoolbox
+  tool_panel_section_label: ChemicalToolBox
+- name: gmx_merge_topology_files
+  owner: chemteam
+  revisions:
+  - 534ff13ea227
+  tool_panel_section_id: chemicaltoolbox
+  tool_panel_section_label: ChemicalToolBox
+- name: parmconv
+  owner: chemteam
+  revisions:
+  - 5a97cb53a456
+  tool_panel_section_id: chemicaltoolbox
+  tool_panel_section_label: ChemicalToolBox
+- name: md_converter
+  owner: chemteam
+  revisions:
+  - ba83f0923369
+  tool_panel_section_id: chemicaltoolbox
+  tool_panel_section_label: ChemicalToolBox
+- name: ambertools_acpype
+  owner: chemteam
+  revisions:
+  - a0c154146234
+  tool_panel_section_id: chemicaltoolbox
+  tool_panel_section_label: ChemicalToolBox
+- name: biomd_neqgamma
+  owner: chemteam
+  revisions:
+  - afcb925def69
+  tool_panel_section_id: chemicaltoolbox
+  tool_panel_section_label: ChemicalToolBox
+- name: ambertools_antechamber
+  owner: chemteam
+  revisions:
+  - 4fff93efc0f9
+  tool_panel_section_id: chemicaltoolbox
+  tool_panel_section_label: ChemicalToolBox
+- name: mmpbsa_mmgbsa
+  owner: chemteam
+  revisions:
+  - 45dc2555933c
   tool_panel_section_id: chemicaltoolbox
   tool_panel_section_label: ChemicalToolBox

--- a/usegalaxy.org/text_manipulation.yml
+++ b/usegalaxy.org/text_manipulation.yml
@@ -42,3 +42,5 @@ tools:
   owner: iuc
 - name: column_arrange_by_header
   owner: bgruening
+- name: add_line_to_file
+  owner: bgruening

--- a/usegalaxy.org/text_manipulation.yml.lock
+++ b/usegalaxy.org/text_manipulation.yml.lock
@@ -6,19 +6,19 @@ tools:
 - name: column_maker
   owner: devteam
   revisions:
-  - 427903d47026
+  - 02026300aa45
   - 13b6f0007d9e
+  - 427903d47026
   - 464b9305180e
   - 6e8d94597139
-  - 02026300aa45
   tool_panel_section_id: text_manipulation
   tool_panel_section_label: Text Manipulation
 - name: annotatemyids
   owner: iuc
   revisions:
   - 1aae04680c4b
-  - b5d8e5475247
   - 44018dd6b447
+  - b5d8e5475247
   - f29602ae449e
   tool_panel_section_id: text_manipulation
   tool_panel_section_label: Text Manipulation
@@ -54,8 +54,8 @@ tools:
   owner: iuc
   revisions:
   - 1aae04680c4b
-  - b5d8e5475247
   - 44018dd6b447
+  - b5d8e5475247
   - f29602ae449e
   tool_panel_section_id: text_manipulation
   tool_panel_section_label: Text Manipulation
@@ -99,8 +99,8 @@ tools:
   owner: iuc
   revisions:
   - 60ff16842fcd
-  - dddadbbac949
   - 93a3ce78ce55
+  - dddadbbac949
   tool_panel_section_id: text_manipulation
   tool_panel_section_label: Text Manipulation
 - name: regex_find_replace
@@ -119,8 +119,8 @@ tools:
   owner: iuc
   revisions:
   - 1ea4e668bf73
-  - 33d61c89fb8d
   - 2e8f945f7285
+  - 33d61c89fb8d
   - 83069b38aa85
   - cf34c344508d
   tool_panel_section_id: text_manipulation
@@ -129,10 +129,10 @@ tools:
   owner: iuc
   revisions:
   - 6e72fd26a9d3
-  - f31bb1e5725d
-  - dfe38b7c34ed
   - bce29ec10b78
   - c29d2f80a066
+  - dfe38b7c34ed
+  - f31bb1e5725d
   tool_panel_section_id: text_manipulation
   tool_panel_section_label: Text Manipulation
 - name: concatenate_multiple_datasets
@@ -153,5 +153,11 @@ tools:
   owner: bgruening
   revisions:
   - 6c6d26ff01ff
+  tool_panel_section_id: text_manipulation
+  tool_panel_section_label: Text Manipulation
+- name: add_line_to_file
+  owner: bgruening
+  revisions:
+  - 8e251055b1a9
   tool_panel_section_id: text_manipulation
   tool_panel_section_label: Text Manipulation


### PR DESCRIPTION
I have a PR open for some IWC workflows here: https://github.com/galaxyproject/iwc/pull/68

However, IWC testing is using the tools installed on usegalaxy.org (via CVMFS) and some of them are missing, so tests are failing. It would be great if these tools could be installed on .org.