### PR TITLE
Emboss: update last version

### DIFF
--- a/usegalaxy.org/emboss.yml.lock
+++ b/usegalaxy.org/emboss.yml.lock
@@ -9,5 +9,6 @@ tools:
   - dba489bfcd62
   - dc492eb6a4fc
   - ce385837c160
+  - 63dd26468588
   tool_panel_section_id: emboss
   tool_panel_section_label: EMBOSS


### PR DESCRIPTION
A user reported a problem with one of the EMBOSS tools (transeq) in [GHelp](https://help.galaxyproject.org/t/transeq-cannot-be-invoked-through-the-search-bar/7502). I think that it will fix the problem.