### PR TITLE
Update Du Novo to 3.0.2.

### DIFF
--- a/test.galaxyproject.org/du_novo.yml
+++ b/test.galaxyproject.org/du_novo.yml
@@ -2,8 +2,6 @@ tool_panel_section_label: Du Novo
 tools:
 - name: dunovo
   owner: nick
-- name: duplex
-  owner: nick
 - name: sequence_content_trimmer
   owner: nick
 - name: duplex_family_size_distribution

--- a/test.galaxyproject.org/du_novo.yml.lock
+++ b/test.galaxyproject.org/du_novo.yml.lock
@@ -7,6 +7,7 @@ tools:
   owner: nick
   revisions:
   - 9dc43bf7d1db
+  - 0f8e0dc73d1d
   tool_panel_section_id: du_novo
   tool_panel_section_label: Du Novo
 - name: duplex

--- a/usegalaxy.org/du_novo.yml.lock
+++ b/usegalaxy.org/du_novo.yml.lock
@@ -7,6 +7,7 @@ tools:
   owner: nick
   revisions:
   - 9dc43bf7d1db
+  - 0f8e0dc73d1d
   tool_panel_section_id: du_novo
   tool_panel_section_label: Du Novo
 - name: sequence_content_trimmer


### PR DESCRIPTION
New Du Novo release.

I updated the tool on both Test and Main - I've tested it locally and I think it should be good to go. But let me know if I should roll it back on Main and proceed more cautiously.

I also removed a duplicate repository from Test - `duplex` is a deprecated repository and is basically just the old version of `dunovo`.