### PR TITLE
Du Novo: Remove duplicate "duplex" repository from Test.

### DIFF
--- a/test.galaxyproject.org/du_novo.yml
+++ b/test.galaxyproject.org/du_novo.yml
@@ -2,8 +2,6 @@ tool_panel_section_label: Du Novo
 tools:
 - name: dunovo
   owner: nick
-- name: duplex
-  owner: nick
 - name: sequence_content_trimmer
   owner: nick
 - name: duplex_family_size_distribution

--- a/test.galaxyproject.org/du_novo.yml.lock
+++ b/test.galaxyproject.org/du_novo.yml.lock
@@ -9,12 +9,6 @@ tools:
   - 9dc43bf7d1db
   tool_panel_section_id: du_novo
   tool_panel_section_label: Du Novo
-- name: duplex
-  owner: nick
-  revisions:
-  - 9a0bee12b583
-  tool_panel_section_id: du_novo
-  tool_panel_section_label: Du Novo
 - name: sequence_content_trimmer
   owner: nick
   revisions:


### PR DESCRIPTION
test.galaxyproject.org had a duplicate version of Du Novo with the repo name "duplex". This is an obsolete version of the repo before it was renamed to "dunovo".

I manually edited the lock file, removing the entire "duplex" section. Hopefully I did it correctly?