### PR TITLE
Bump ChemicalToolBox for missing tools

### DIFF
--- a/usegalaxy.org/chemicaltoolbox.yml.lock
+++ b/usegalaxy.org/chemicaltoolbox.yml.lock
@@ -1,5 +1,5 @@
 install_repository_dependencies: true
-install_resolver_dependencies: true
+install_resolver_dependencies: false
 install_tool_dependencies: false
 tool_panel_section_label: ChemicalToolBox
 tools:


### PR DESCRIPTION
I removed all of the ChemicalToolBox from usegalaxy.org's `shed_tool_conf.xml` before deploying #492 and it seems that perhaps the CVMFS cache did not update properly when I did, because some tools were reported as already installed that should not have been. This should cause them to be reinstalled.