### PR TITLE
Update table_annovar on usegalaxy.org

### DIFF
--- a/usegalaxy.org/variant_calling.yml.lock
+++ b/usegalaxy.org/variant_calling.yml.lock
@@ -50,7 +50,7 @@ tools:
 - name: table_annovar
   owner: devteam
   revisions:
-  - 08b003ee9db7
+  - d4e292ddda05
   tool_panel_section_id: variant_calling
   tool_panel_section_label: Variant Calling
 - name: mutate_snp_codon


### PR DESCRIPTION
I removed the two previous versions, we're actually going to hide this, we just want a version installed for seeing parameters of old runs and that sort of thing.

## Installation sequence for `tool-installers`
- [x] Test using `@galaxybot test this`
- [x] Inspect CI output for expected changes
- [x] Deploy using `@galaxybot deploy this` if test install was successful
- [x] Merge this PR
