### PR TITLE
Update the Sequence Content Trimmer to 0.2.3.

### DIFF
--- a/test.galaxyproject.org/du_novo.yml.lock
+++ b/test.galaxyproject.org/du_novo.yml.lock
@@ -19,6 +19,7 @@ tools:
   owner: nick
   revisions:
   - 7f170cb06e2e
+  - 464aee13e2df
   tool_panel_section_id: du_novo
   tool_panel_section_label: Du Novo
 - name: duplex_family_size_distribution


### PR DESCRIPTION
This updates the Sequence Content Trimmer with a number of improvements made over the years which haven't yet been deployed.

Most importantly, it addresses an error reported on usegalaxy.org which was apparently due to the fact that it relied on Python 2.

## Installation sequence for `tool-installers`
- [x] Test using `@galaxybot test this`
- [x] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
