### PR TITLE
Adds seqcomplexity tool to statistics list

### DIFF
--- a/usegalaxy.org/statistics.yml
+++ b/usegalaxy.org/statistics.yml
@@ -61,7 +61,7 @@ tools:
 - name: seq_composition
   owner: peterjc
 - name: seqcomplexity
-  owner: iuc 
+  owner: iuc
 - name: scipy_sparse
   owner: bgruening
 - name: create_tool_recommendation_model

--- a/usegalaxy.org/statistics.yml
+++ b/usegalaxy.org/statistics.yml
@@ -60,6 +60,8 @@ tools:
   owner: lecorguille
 - name: seq_composition
   owner: peterjc
+- name: seqcomplexity
+  owner: iuc 
 - name: scipy_sparse
   owner: bgruening
 - name: create_tool_recommendation_model

--- a/usegalaxy.org/statistics.yml.lock
+++ b/usegalaxy.org/statistics.yml.lock
@@ -183,6 +183,12 @@ tools:
   - 13be788233da
   tool_panel_section_id: statistics
   tool_panel_section_label: Statistics
+- name: seqcomplexity
+  owner: iuc
+  revisions:
+  - f14a21f3d5b1
+  tool_panel_section_id: statistics
+  tool_panel_section_label: Statistics
 - name: scipy_sparse
   owner: bgruening
   revisions:


### PR DESCRIPTION
Adds seqcomplexity tool to statistics list. It is a part of our initiative with the FDA to create reproducible metrics on raw reference sequence data. 

Tool can be found here
https://toolshed.g2.bx.psu.edu/view/iuc/seqcomplexity/f14a21f3d5b1

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
