### PR TITLE
Revert "Add map_param_value"

### DIFF
--- a/usegalaxy.org/expression_tools.yml
+++ b/usegalaxy.org/expression_tools.yml
@@ -2,5 +2,3 @@ tool_panel_section_id: expression_tools
 tools:
   - name: compose_text_param
     owner: iuc
-  - name: map_param_value
-    owner: iuc

--- a/usegalaxy.org/expression_tools.yml.lock
+++ b/usegalaxy.org/expression_tools.yml.lock
@@ -1,16 +1,11 @@
 install_repository_dependencies: false
-install_resolver_dependencies: false
+install_resolver_dependencies: true
 install_tool_dependencies: false
 tool_panel_section_id: expression_tools
 tools:
 - name: compose_text_param
   owner: iuc
   revisions:
-  - e188c9826e0f
   - feb3acba1e0a
-  tool_panel_section_id: expression_tools
-- name: map_param_value
-  owner: iuc
-  revisions:
-  - 43d7b3642a30
+  - e188c9826e0f
   tool_panel_section_id: expression_tools


### PR DESCRIPTION
This reverts commit d388856f935af259e13c8044c6292f7fe81e0ef5.

Maybe renaming the file was the issue ?

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
