### PR TITLE
added the new gmx tool ids for gmx_rmsf and gmx_rmsd to usegalaxy.eu and usegalaxy.org

### DIFF
--- a/usegalaxy.eu/chemicaltoolbox.yml
+++ b/usegalaxy.eu/chemicaltoolbox.yml
@@ -52,6 +52,10 @@ tools:
   owner: chemteam
 - name: gmx_npt
   owner: chemteam
+- name: gmx_rmsd
+  owner: chemteam
+- name: gmx_rmsf
+  owner: chemteam
 - name: openbabel
   owner: bgruening
 - name: osra

--- a/usegalaxy.org/chemicaltoolbox.yml
+++ b/usegalaxy.org/chemicaltoolbox.yml
@@ -62,6 +62,10 @@ tools:
   owner: chemteam
 - name: gmx_trj
   owner: chemteam
+- name: gmx_rmsd
+  owner: chemteam
+- name: gmx_rmsf
+  owner: chemteam
 - name: alphafold2
   owner: galaxy-australia
 - name: gromacs_extract_topology


### PR DESCRIPTION

added the new gmx tool ids for gmx_rmsf and gmx_rmsd to usegalaxy.eu and usegalaxy.org.

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [x] Merge this PR
