### PR TITLE
Remove mixcr_analyze from usegalaxy.org

### DIFF
--- a/usegalaxy.org/variant_calling.yml
+++ b/usegalaxy.org/variant_calling.yml
@@ -46,8 +46,6 @@ tools:
   owner: crs4
 - name: gatk4_mutect2
   owner: iuc
-- name: mixcr_analyze
-  owner: iuc
 - name: ococo
   owner: iuc
 - name: varscan_copynumber

--- a/usegalaxy.org/variant_calling.yml.lock
+++ b/usegalaxy.org/variant_calling.yml.lock
@@ -195,12 +195,6 @@ tools:
   - fb0bb7174530
   tool_panel_section_id: variant_calling
   tool_panel_section_label: Variant Calling
-- name: mixcr_analyze
-  owner: iuc
-  revisions:
-  - d38cfb922f95
-  tool_panel_section_id: variant_calling
-  tool_panel_section_label: Variant Calling
 - name: ococo
   owner: iuc
   revisions:


### PR DESCRIPTION
Note this doesn't actually remove it (I will have to do that by hand), but it prevents it from being reinstalled after I remove it.

Fixes #569

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
