### PR TITLE
Add chopin2 to the Machine Learning panel

### DIFF
--- a/usegalaxy.org/machine_learning.yml
+++ b/usegalaxy.org/machine_learning.yml
@@ -64,3 +64,5 @@ tools:
   owner: bgruening
 - name: create_tool_recommendation_model
   owner: bgruening
+- name: chopin2
+  owner: iuc

--- a/usegalaxy.org/machine_learning.yml.lock
+++ b/usegalaxy.org/machine_learning.yml.lock
@@ -356,3 +356,9 @@ tools:
   - e94dc7945639
   tool_panel_section_id: machine_learning
   tool_panel_section_label: Machine Learning
+- name: chopin2
+  owner: iuc
+  revisions:
+  - d49893faf877
+  tool_panel_section_id: machine_learning
+  tool_panel_section_label: Machine Learning


### PR DESCRIPTION
This adds the `chopin2` tool to the Machine Learning panel in [usegalaxy.org](usegalaxy.org)
[https://toolshed.g2.bx.psu.edu/view/iuc/chopin2](https://toolshed.g2.bx.psu.edu/view/iuc/chopin2)

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
