### PR TITLE
QIIME2 suite (for cloud deployments like AnVIL)

### DIFF
--- a/cloud/qiime2.yml
+++ b/cloud/qiime2.yml
@@ -1,0 +1,4 @@
+tool_panel_section_label: QIIME2
+tools:
+- name: suite_qiime2_core
+  owner: q2d2

--- a/cloud/qiime2.yml.lock
+++ b/cloud/qiime2.yml.lock
@@ -1,0 +1,10 @@
+install_repository_dependencies: true
+install_resolver_dependencies: true
+install_tool_dependencies: false
+tool_panel_section_label: QIIME2
+tools:
+- name: suite_qiime2_core
+  owner: q2d2
+  revisions: []
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2

--- a/cloud/qiime2.yml.lock
+++ b/cloud/qiime2.yml.lock
@@ -1,10 +1,11 @@
-install_repository_dependencies: true
-install_resolver_dependencies: true
+install_repository_dependencies: false
+install_resolver_dependencies: false
 install_tool_dependencies: false
 tool_panel_section_label: QIIME2
 tools:
 - name: suite_qiime2_core
   owner: q2d2
-  revisions: []
+  revisions:
+  - 3f011fac899d
   tool_panel_section_id: qiime2
   tool_panel_section_label: QIIME2


### PR DESCRIPTION
Adding the [QIIME2 Galaxy tool suite](https://github.com/qiime2/galaxy-tools)[1] to cloud deployments with the `install_*` parameters set to `false` as the tools are all containerized. For the same PR to main, see #599

[1]: relevant datatype added to galaxy [in 22.05](https://github.com/galaxyproject/galaxy/pull/14216)

## Installation sequence for `tool-installers`
- [x] Test using `@galaxybot test this`
- [x] Inspect CI output for expected changes
- [x] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
