### PR TITLE
fixing borked cloud deployment update

### DIFF
--- a/cloud/qiime2.yml.lock
+++ b/cloud/qiime2.yml.lock
@@ -1,4 +1,4 @@
-install_repository_dependencies: false
+install_repository_dependencies: true
 install_resolver_dependencies: false
 install_tool_dependencies: false
 tool_panel_section_label: QIIME2
@@ -7,5 +7,4 @@ tools:
   owner: q2d2
   revisions:
   - 3f011fac899d
-  tool_panel_section_id: qiime2
   tool_panel_section_label: QIIME2


### PR DESCRIPTION
per [this comment](https://github.com/galaxyproject/usegalaxy-tools/pull/600#issuecomment-1531561340) on the ill-fated #600, i've removed `tool_panel_section_id` and changed `install_repository_dependencies` to `true`

## Installation sequence for `tool-installers`
- [x] Test using `@galaxybot test this`
- [x] Inspect CI output for expected changes
- [x] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
