### PR TITLE
Add tools required for Metabolomics trainings for MS data processing

### DIFF
--- a/usegalaxy.org/training_metabolomics.yml
+++ b/usegalaxy.org/training_metabolomics.yml
@@ -28,3 +28,15 @@ tools:
   owner: recetox
 - name: waveica
   owner: recetox
+- name: camera_annotate
+  owner: lecorguille
+- name: xcms_export_samplemetadata
+  owner: lecorguille
+- name: xcms_plot_chromatogram
+  owner: lecorguille
+- name: xcms_summary
+  owner: lecorguille
+- name: idchoice
+  owner: melpetera
+- name: intensity_checks
+  owner: melpetera

--- a/usegalaxy.org/training_metabolomics.yml
+++ b/usegalaxy.org/training_metabolomics.yml
@@ -1,0 +1,30 @@
+tool_panel_section_label: Metabolomics
+tools:
+- name: msconvert
+  owner: galaxyp
+- name: msnbase_readmsdata
+  owner: lecorguille
+- name: xcms_fillpeaks
+  owner: lecorguille
+- name: xcms_group
+  owner: lecorguille
+- name: xcms_merge
+  owner: lecorguille
+- name: xcms_retcor
+  owner: lecorguille
+- name: xcms_xcmsset
+  owner: lecorguille
+- name: matchms
+  owner: recetox
+- name: matchms_filtering
+  owner: recetox
+- name: matchms_formatter
+  owner: recetox
+- name: ramclustr
+  owner: recetox
+- name: ramclustr_define_experiment
+  owner: recetox
+- name: riassigner
+  owner: recetox
+- name: waveica
+  owner: recetox

--- a/usegalaxy.org/training_metabolomics.yml.lock
+++ b/usegalaxy.org/training_metabolomics.yml.lock
@@ -1,0 +1,65 @@
+---
+install_tool_dependencies: true
+install_repository_dependencies: false
+install_resolver_dependencies: false
+tools:
+- name: msconvert
+  owner: galaxyp
+  revisions: 6153e8ada1ee
+  tool_panel_section_label: Metabolomics
+- name: msnbase_readmsdata
+  owner: lecorguille
+  revisions: 11ab2081bd4a
+  tool_panel_section_label: Metabolomics
+- name: xcms_fillpeaks
+  owner: lecorguille
+  revisions: 26d77e9ceb49
+  tool_panel_section_label: Metabolomics
+- name: xcms_group
+  owner: lecorguille
+  revisions: d45a786cbc40
+  tool_panel_section_label: Metabolomics
+- name: xcms_merge
+  owner: lecorguille
+  revisions: 5bd125a3f3b0
+  tool_panel_section_label: Metabolomics
+- name: xcms_retcor
+  owner: lecorguille
+  revisions: aa252eec9229
+  tool_panel_section_label: Metabolomics
+- name: xcms_xcmsset
+  owner: lecorguille
+  revisions: b02d1992a43a
+  tool_panel_section_label: Metabolomics
+- name: matchms
+  owner: recetox
+  revisions: 4015f250a5a1
+  tool_panel_section_label: Metabolomics
+- name: matchms_filtering
+  owner: recetox
+  revisions: 357df6c47d92
+  tool_panel_section_label: Metabolomics
+- name: matchms_formatter
+  owner: recetox
+  revisions: 715fe77be601
+  tool_panel_section_label: Metabolomics
+- name: ramclustr
+  owner: recetox
+  revisions: 2ec9253a647e
+  tool_panel_section_label: Metabolomics
+- name: ramclustr_define_experiment
+  owner: recetox
+  revisions: 25625114618e
+  tool_panel_section_label: Metabolomics
+- name: riassigner
+  owner: recetox
+  revisions: f6bf8f1f3224
+  tool_panel_section_label: Metabolomics
+- name: riassigner
+  owner: recetox
+  revisions: c702620c22b1
+  tool_panel_section_label: Metabolomics
+- name: waveica
+  owner: recetox
+  revisions: b77023c41c76
+  tool_panel_section_label: Metabolomics

--- a/usegalaxy.org/training_metabolomics.yml.lock
+++ b/usegalaxy.org/training_metabolomics.yml.lock
@@ -5,89 +5,111 @@ install_resolver_dependencies: false
 tools:
 - name: msconvert
   owner: galaxyp
-  revisions: 6153e8ada1ee
+  revisions: 
+  - 6153e8ada1ee
   tool_panel_section_label: Metabolomics
 - name: msnbase_readmsdata
   owner: lecorguille
-  revisions: 11ab2081bd4a
+  revisions: 
+  - 11ab2081bd4a
   tool_panel_section_label: Metabolomics
 - name: xcms_fillpeaks
   owner: lecorguille
-  revisions: 26d77e9ceb49
+  revisions:
+  - 26d77e9ceb49
   tool_panel_section_label: Metabolomics
 - name: xcms_group
   owner: lecorguille
-  revisions: d45a786cbc40
+  revisions:
+  - d45a786cbc40
   tool_panel_section_label: Metabolomics
 - name: xcms_merge
   owner: lecorguille
-  revisions: 5bd125a3f3b0
+  revisions:
+  - 5bd125a3f3b0
   tool_panel_section_label: Metabolomics
 - name: xcms_retcor
   owner: lecorguille
-  revisions: aa252eec9229
+  revisions:
+  - aa252eec9229
   tool_panel_section_label: Metabolomics
 - name: xcms_xcmsset
   owner: lecorguille
-  revisions: b02d1992a43a
+  revisions:
+  - b02d1992a43a
   tool_panel_section_label: Metabolomics
 - name: matchms
   owner: recetox
-  revisions: 4015f250a5a1
+  revisions:
+  - 4015f250a5a1
   tool_panel_section_label: Metabolomics
 - name: matchms_filtering
   owner: recetox
-  revisions: 357df6c47d92
+  revisions:
+  - 357df6c47d92
   tool_panel_section_label: Metabolomics
 - name: matchms_formatter
   owner: recetox
-  revisions: 715fe77be601
+  revisions:
+  - 715fe77be601
   tool_panel_section_label: Metabolomics
 - name: ramclustr
   owner: recetox
-  revisions: 2ec9253a647e
+  revisions:
+  - 2ec9253a647e
   tool_panel_section_label: Metabolomics
 - name: ramclustr_define_experiment
   owner: recetox
-  revisions: 25625114618e
+  revisions:
+  - 25625114618e
   tool_panel_section_label: Metabolomics
 - name: riassigner
   owner: recetox
-  revisions: f6bf8f1f3224
+  revisions:
+  - f6bf8f1f3224
   tool_panel_section_label: Metabolomics
 - name: riassigner
   owner: recetox
-  revisions: c702620c22b1
+  revisions:
+  - c702620c22b1
   tool_panel_section_label: Metabolomics
 - name: waveica
   owner: recetox
-  revisions: b77023c41c76
+  revisions:
+  - b77023c41c76
   tool_panel_section_label: Metabolomics
 - name: camera_annotate
   owner: lecorguille
-  revisions: 512c2b701d96
+  revisions:
+  - 512c2b701d96
   tool_panel_section_label: Metabolomics
 - name: msnbase_readmsdata
   owner: lecorguille
-  revisions: 11ab2081bd4a
+  revisions:
+  - 11ab2081bd4a
   tool_panel_section_label: Metabolomics
 - name: xcms_export_samplemetadata
   owner: lecorguille
-  revisions: 94eb263cfab4
+  revisions:
+  - 94eb263cfab4
   tool_panel_section_label: Metabolomics
 - name: xcms_plot_chromatogram
   owner: lecorguille
-  revisions: '024974037c4e'
+  revisions:
+  - '024974037c4e'
   tool_panel_section_label: Metabolomics
 - name: xcms_summary
   owner: lecorguille
-  revisions: '018a9771de28'
+  revisions:
+  - '018a9771de28'
   tool_panel_section_label: Metabolomics
 - name: idchoice
   owner: melpetera
-  revisions: bb19b1d15732
+  revisions:
+  - bb19b1d15732
   tool_panel_section_label: Metabolomics
 - name: intensity_checks
   owner: melpetera
-  revisions: a31f3f802b2b
+  revisions:
+  - a31f3f802b2b
   tool_panel_section_label: Metabolomics

--- a/usegalaxy.org/training_metabolomics.yml.lock
+++ b/usegalaxy.org/training_metabolomics.yml.lock
@@ -63,3 +63,31 @@ tools:
   owner: recetox
   revisions: b77023c41c76
   tool_panel_section_label: Metabolomics
+- name: camera_annotate
+  owner: lecorguille
+  revisions: 512c2b701d96
+  tool_panel_section_label: Metabolomics
+- name: msnbase_readmsdata
+  owner: lecorguille
+  revisions: 11ab2081bd4a
+  tool_panel_section_label: Metabolomics
+- name: xcms_export_samplemetadata
+  owner: lecorguille
+  revisions: 94eb263cfab4
+  tool_panel_section_label: Metabolomics
+- name: xcms_plot_chromatogram
+  owner: lecorguille
+  revisions: '024974037c4e'
+  tool_panel_section_label: Metabolomics
+- name: xcms_summary
+  owner: lecorguille
+  revisions: '018a9771de28'
+  tool_panel_section_label: Metabolomics
+- name: idchoice
+  owner: melpetera
+  revisions: bb19b1d15732
+  tool_panel_section_label: Metabolomics
+- name: intensity_checks
+  owner: melpetera
+  revisions: a31f3f802b2b
+  tool_panel_section_label: Metabolomics


### PR DESCRIPTION
This PR adds the tools required for two Metabolomics training published in the GTN.

@natefoo let me know if something else is needed or has to be changed.

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
