### PR TITLE
Update AlphaFold on .org

### DIFF
--- a/usegalaxy.org/chemicaltoolbox.yml.lock
+++ b/usegalaxy.org/chemicaltoolbox.yml.lock
@@ -239,7 +239,7 @@ tools:
 - name: alphafold2
   owner: galaxy-australia
   revisions:
-  - 04e95886cf24
+  - 5b85006245f3
   tool_panel_section_id: chemicaltoolbox
   tool_panel_section_label: ChemicalToolBox
 - name: gromacs_extract_topology


### PR DESCRIPTION
Version 2.3 databases are now on CVMFS at `/cvmfs/data.galaxyproject.org/byhand/alphafold/2.3`

I removed the 2.1 version that's already installed from Main's `shed_tool_conf.xml` by hand since this never worked on .org due to the lack of databases.

## Installation sequence for `tool-installers`
- [x] Test using `@galaxybot test this`
- [x] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
