### PR TITLE
Remove Genome Diversity tools

### DIFF
--- a/usegalaxy.org/genome_diversity.yml
+++ b/usegalaxy.org/genome_diversity.yml
@@ -1,6 +1,4 @@
 tool_panel_section_label: Genome Diversity
 tools:
-- name: genome_diversity
-  owner: miller-lab
 - name: raxml
   owner: iuc

--- a/usegalaxy.org/genome_diversity.yml.lock
+++ b/usegalaxy.org/genome_diversity.yml.lock
@@ -3,12 +3,6 @@ install_resolver_dependencies: false
 install_tool_dependencies: false
 tool_panel_section_label: Genome Diversity
 tools:
-- name: genome_diversity
-  owner: miller-lab
-  revisions:
-  - e56023008e36
-  tool_panel_section_id: genome_diversity
-  tool_panel_section_label: Genome Diversity
 - name: raxml
   owner: iuc
   revisions:


### PR DESCRIPTION
Most of these tools have been broken for a long time, they are tightly coupled with Galaxy internals (e.g. `galaxy.eggs`) as of 10 years ago and there is no support for updating them.

As always, this does not actually remove them, it just prevents them from being reinstalled after I remove them manually.

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
