### PR TITLE
add qiime2 to main

### DIFF
--- a/usegalaxy.org/qiime2.yml
+++ b/usegalaxy.org/qiime2.yml
@@ -1,0 +1,324 @@
+tool_panel_section_label: QIIME2
+tools:
+  - name: qiime2__alignment__mafft
+    owner: q2d2
+  - name: qiime2__alignment__mafft_add
+    owner: q2d2
+  - name: qiime2__alignment__mask
+    owner: q2d2
+  - name: qiime2__composition__add_pseudocount
+    owner: q2d2
+  - name: qiime2__composition__ancom
+    owner: q2d2
+  - name: qiime2__composition__ancombc
+    owner: q2d2
+  - name: qiime2__composition__tabulate
+    owner: q2d2
+  - name: qiime2__cutadapt__demux_paired
+    owner: q2d2
+  - name: qiime2__cutadapt__demux_single
+    owner: q2d2
+  - name: qiime2__cutadapt__trim_paired
+    owner: q2d2
+  - name: qiime2__cutadapt__trim_single
+    owner: q2d2
+  - name: qiime2__dada2__denoise_ccs
+    owner: q2d2
+  - name: qiime2__dada2__denoise_paired
+    owner: q2d2
+  - name: qiime2__dada2__denoise_pyro
+    owner: q2d2
+  - name: qiime2__dada2__denoise_single
+    owner: q2d2
+  - name: qiime2__deblur__denoise_16S
+    owner: q2d2
+  - name: qiime2__deblur__denoise_other
+    owner: q2d2
+  - name: qiime2__deblur__visualize_stats
+    owner: q2d2
+  - name: qiime2__demux__emp_paired
+    owner: q2d2
+  - name: qiime2__demux__emp_single
+    owner: q2d2
+  - name: qiime2__demux__filter_samples
+    owner: q2d2
+  - name: qiime2__demux__subsample_paired
+    owner: q2d2
+  - name: qiime2__demux__subsample_single
+    owner: q2d2
+  - name: qiime2__demux__summarize
+    owner: q2d2
+  - name: qiime2__diversity__adonis
+    owner: q2d2
+  - name: qiime2__diversity__alpha
+    owner: q2d2
+  - name: qiime2__diversity__alpha_correlation
+    owner: q2d2
+  - name: qiime2__diversity__alpha_group_significance
+    owner: q2d2
+  - name: qiime2__diversity__alpha_phylogenetic
+    owner: q2d2
+  - name: qiime2__diversity__alpha_rarefaction
+    owner: q2d2
+  - name: qiime2__diversity__beta
+    owner: q2d2
+  - name: qiime2__diversity__beta_correlation
+    owner: q2d2
+  - name: qiime2__diversity__beta_group_significance
+    owner: q2d2
+  - name: qiime2__diversity__beta_phylogenetic
+    owner: q2d2
+  - name: qiime2__diversity__beta_rarefaction
+    owner: q2d2
+  - name: qiime2__diversity__bioenv
+    owner: q2d2
+  - name: qiime2__diversity__core_metrics
+    owner: q2d2
+  - name: qiime2__diversity__core_metrics_phylogenetic
+    owner: q2d2
+  - name: qiime2__diversity__filter_distance_matrix
+    owner: q2d2
+  - name: qiime2__diversity__mantel
+    owner: q2d2
+  - name: qiime2__diversity__pcoa
+    owner: q2d2
+  - name: qiime2__diversity__pcoa_biplot
+    owner: q2d2
+  - name: qiime2__diversity__procrustes_analysis
+    owner: q2d2
+  - name: qiime2__diversity__tsne
+    owner: q2d2
+  - name: qiime2__diversity__umap
+    owner: q2d2
+  - name: qiime2__diversity_lib__alpha_passthrough
+    owner: q2d2
+  - name: qiime2__diversity_lib__beta_passthrough
+    owner: q2d2
+  - name: qiime2__diversity_lib__beta_phylogenetic_meta_passthrough
+    owner: q2d2
+  - name: qiime2__diversity_lib__beta_phylogenetic_passthrough
+    owner: q2d2
+  - name: qiime2__diversity_lib__bray_curtis
+    owner: q2d2
+  - name: qiime2__diversity_lib__faith_pd
+    owner: q2d2
+  - name: qiime2__diversity_lib__jaccard
+    owner: q2d2
+  - name: qiime2__diversity_lib__observed_features
+    owner: q2d2
+  - name: qiime2__diversity_lib__pielou_evenness
+    owner: q2d2
+  - name: qiime2__diversity_lib__shannon_entropy
+    owner: q2d2
+  - name: qiime2__diversity_lib__unweighted_unifrac
+    owner: q2d2
+  - name: qiime2__diversity_lib__weighted_unifrac
+    owner: q2d2
+  - name: qiime2__emperor__biplot
+    owner: q2d2
+  - name: qiime2__emperor__plot
+    owner: q2d2
+  - name: qiime2__emperor__procrustes_plot
+    owner: q2d2
+  - name: qiime2__feature_classifier__blast
+    owner: q2d2
+  - name: qiime2__feature_classifier__classify_consensus_blast
+    owner: q2d2
+  - name: qiime2__feature_classifier__classify_consensus_vsearch
+    owner: q2d2
+  - name: qiime2__feature_classifier__classify_hybrid_vsearch_sklearn
+    owner: q2d2
+  - name: qiime2__feature_classifier__classify_sklearn
+    owner: q2d2
+  - name: qiime2__feature_classifier__extract_reads
+    owner: q2d2
+  - name: qiime2__feature_classifier__find_consensus_annotation
+    owner: q2d2
+  - name: qiime2__feature_classifier__fit_classifier_naive_bayes
+    owner: q2d2
+  - name: qiime2__feature_classifier__fit_classifier_sklearn
+    owner: q2d2
+  - name: qiime2__feature_classifier__vsearch_global
+    owner: q2d2
+  - name: qiime2__feature_table__core_features
+    owner: q2d2
+  - name: qiime2__feature_table__filter_features
+    owner: q2d2
+  - name: qiime2__feature_table__filter_features_conditionally
+    owner: q2d2
+  - name: qiime2__feature_table__filter_samples
+    owner: q2d2
+  - name: qiime2__feature_table__filter_seqs
+    owner: q2d2
+  - name: qiime2__feature_table__group
+    owner: q2d2
+  - name: qiime2__feature_table__heatmap
+    owner: q2d2
+  - name: qiime2__feature_table__merge
+    owner: q2d2
+  - name: qiime2__feature_table__merge_seqs
+    owner: q2d2
+  - name: qiime2__feature_table__merge_taxa
+    owner: q2d2
+  - name: qiime2__feature_table__presence_absence
+    owner: q2d2
+  - name: qiime2__feature_table__rarefy
+    owner: q2d2
+  - name: qiime2__feature_table__relative_frequency
+    owner: q2d2
+  - name: qiime2__feature_table__rename_ids
+    owner: q2d2
+  - name: qiime2__feature_table__subsample
+    owner: q2d2
+  - name: qiime2__feature_table__summarize
+    owner: q2d2
+  - name: qiime2__feature_table__tabulate_seqs
+    owner: q2d2
+  - name: qiime2__feature_table__transpose
+    owner: q2d2
+  - name: qiime2__fragment_insertion__classify_otus_experimental
+    owner: q2d2
+  - name: qiime2__fragment_insertion__filter_features
+    owner: q2d2
+  - name: qiime2__fragment_insertion__sepp
+    owner: q2d2
+  - name: qiime2__gneiss__assign_ids
+    owner: q2d2
+  - name: qiime2__gneiss__correlation_clustering
+    owner: q2d2
+  - name: qiime2__gneiss__dendrogram_heatmap
+    owner: q2d2
+  - name: qiime2__gneiss__gradient_clustering
+    owner: q2d2
+  - name: qiime2__gneiss__ilr_hierarchical
+    owner: q2d2
+  - name: qiime2__gneiss__ilr_phylogenetic
+    owner: q2d2
+  - name: qiime2__gneiss__ilr_phylogenetic_differential
+    owner: q2d2
+  - name: qiime2__gneiss__ilr_phylogenetic_ordination
+    owner: q2d2
+  - name: qiime2__longitudinal__anova
+    owner: q2d2
+  - name: qiime2__longitudinal__feature_volatility
+    owner: q2d2
+  - name: qiime2__longitudinal__first_differences
+    owner: q2d2
+  - name: qiime2__longitudinal__first_distances
+    owner: q2d2
+  - name: qiime2__longitudinal__linear_mixed_effects
+    owner: q2d2
+  - name: qiime2__longitudinal__maturity_index
+    owner: q2d2
+  - name: qiime2__longitudinal__nmit
+    owner: q2d2
+  - name: qiime2__longitudinal__pairwise_differences
+    owner: q2d2
+  - name: qiime2__longitudinal__pairwise_distances
+    owner: q2d2
+  - name: qiime2__longitudinal__plot_feature_volatility
+    owner: q2d2
+  - name: qiime2__longitudinal__volatility
+    owner: q2d2
+  - name: qiime2__metadata__distance_matrix
+    owner: q2d2
+  - name: qiime2__metadata__shuffle_groups
+    owner: q2d2
+  - name: qiime2__metadata__tabulate
+    owner: q2d2
+  - name: qiime2__phylogeny__align_to_tree_mafft_fasttree
+    owner: q2d2
+  - name: qiime2__phylogeny__align_to_tree_mafft_iqtree
+    owner: q2d2
+  - name: qiime2__phylogeny__align_to_tree_mafft_raxml
+    owner: q2d2
+  - name: qiime2__phylogeny__fasttree
+    owner: q2d2
+  - name: qiime2__phylogeny__filter_table
+    owner: q2d2
+  - name: qiime2__phylogeny__filter_tree
+    owner: q2d2
+  - name: qiime2__phylogeny__iqtree
+    owner: q2d2
+  - name: qiime2__phylogeny__iqtree_ultrafast_bootstrap
+    owner: q2d2
+  - name: qiime2__phylogeny__midpoint_root
+    owner: q2d2
+  - name: qiime2__phylogeny__raxml
+    owner: q2d2
+  - name: qiime2__phylogeny__raxml_rapid_bootstrap
+    owner: q2d2
+  - name: qiime2__phylogeny__robinson_foulds
+    owner: q2d2
+  - name: qiime2__quality_control__bowtie2_build
+    owner: q2d2
+  - name: qiime2__quality_control__evaluate_composition
+    owner: q2d2
+  - name: qiime2__quality_control__evaluate_seqs
+    owner: q2d2
+  - name: qiime2__quality_control__evaluate_taxonomy
+    owner: q2d2
+  - name: qiime2__quality_control__exclude_seqs
+    owner: q2d2
+  - name: qiime2__quality_control__filter_reads
+    owner: q2d2
+  - name: qiime2__quality_filter__q_score
+    owner: q2d2
+  - name: qiime2__sample_classifier__classify_samples
+    owner: q2d2
+  - name: qiime2__sample_classifier__classify_samples_from_dist
+    owner: q2d2
+  - name: qiime2__sample_classifier__classify_samples_ncv
+    owner: q2d2
+  - name: qiime2__sample_classifier__confusion_matrix
+    owner: q2d2
+  - name: qiime2__sample_classifier__fit_classifier
+    owner: q2d2
+  - name: qiime2__sample_classifier__fit_regressor
+    owner: q2d2
+  - name: qiime2__sample_classifier__heatmap
+    owner: q2d2
+  - name: qiime2__sample_classifier__metatable
+    owner: q2d2
+  - name: qiime2__sample_classifier__predict_classification
+    owner: q2d2
+  - name: qiime2__sample_classifier__predict_regression
+    owner: q2d2
+  - name: qiime2__sample_classifier__regress_samples
+    owner: q2d2
+  - name: qiime2__sample_classifier__regress_samples_ncv
+    owner: q2d2
+  - name: qiime2__sample_classifier__scatterplot
+    owner: q2d2
+  - name: qiime2__sample_classifier__split_table
+    owner: q2d2
+  - name: qiime2__sample_classifier__summarize
+    owner: q2d2
+  - name: qiime2__taxa__barplot
+    owner: q2d2
+  - name: qiime2__taxa__collapse
+    owner: q2d2
+  - name: qiime2__taxa__filter_seqs
+    owner: q2d2
+  - name: qiime2__taxa__filter_table
+    owner: q2d2
+  - name: qiime2__vsearch__cluster_features_closed_reference
+    owner: q2d2
+  - name: qiime2__vsearch__cluster_features_de_novo
+    owner: q2d2
+  - name: qiime2__vsearch__cluster_features_open_reference
+    owner: q2d2
+  - name: qiime2__vsearch__dereplicate_sequences
+    owner: q2d2
+  - name: qiime2__vsearch__fastq_stats
+    owner: q2d2
+  - name: qiime2__vsearch__merge_pairs
+    owner: q2d2
+  - name: qiime2__vsearch__uchime_denovo
+    owner: q2d2
+  - name: qiime2__vsearch__uchime_ref
+    owner: q2d2
+  - name: qiime2_core__tools__export
+    owner: q2d2
+  - name: qiime2_core__tools__import
+    owner: q2d2

--- a/usegalaxy.org/qiime2.yml.lock
+++ b/usegalaxy.org/qiime2.yml.lock
@@ -1,0 +1,970 @@
+install_repository_dependencies: true
+install_resolver_dependencies: false
+install_tool_dependencies: false
+tool_panel_section_label: QIIME2
+tools:
+- name: qiime2__alignment__mafft
+  owner: q2d2
+  revisions:
+  - a0a48c15c573
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__alignment__mafft_add
+  owner: q2d2
+  revisions:
+  - 442d1a046fa6
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__alignment__mask
+  owner: q2d2
+  revisions:
+  - e8bee857dc0d
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__composition__add_pseudocount
+  owner: q2d2
+  revisions:
+  - f92a9f40c7e1
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__composition__ancom
+  owner: q2d2
+  revisions:
+  - e3a9e7cb7b77
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__composition__ancombc
+  owner: q2d2
+  revisions:
+  - fe99db171ce5
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__composition__tabulate
+  owner: q2d2
+  revisions:
+  - 54caf7f5c410
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__cutadapt__demux_paired
+  owner: q2d2
+  revisions:
+  - c6a8822e19f2
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__cutadapt__demux_single
+  owner: q2d2
+  revisions:
+  - d8851a5b9360
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__cutadapt__trim_paired
+  owner: q2d2
+  revisions:
+  - b7fc07bacdb2
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__cutadapt__trim_single
+  owner: q2d2
+  revisions:
+  - 42cd76be2cbf
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__dada2__denoise_ccs
+  owner: q2d2
+  revisions:
+  - d777f76179b6
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__dada2__denoise_paired
+  owner: q2d2
+  revisions:
+  - 06bacd08bb47
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__dada2__denoise_pyro
+  owner: q2d2
+  revisions:
+  - 377a0bd6edd4
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__dada2__denoise_single
+  owner: q2d2
+  revisions:
+  - e7812ca89033
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__deblur__denoise_16S
+  owner: q2d2
+  revisions: []
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__deblur__denoise_other
+  owner: q2d2
+  revisions:
+  - 61ee71aacf1c
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__deblur__visualize_stats
+  owner: q2d2
+  revisions:
+  - 0be892a57bfe
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__demux__emp_paired
+  owner: q2d2
+  revisions:
+  - 551e9187951c
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__demux__emp_single
+  owner: q2d2
+  revisions:
+  - 75b07a996ac0
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__demux__filter_samples
+  owner: q2d2
+  revisions:
+  - 0e5d4dc5c23e
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__demux__subsample_paired
+  owner: q2d2
+  revisions:
+  - f79287ee143e
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__demux__subsample_single
+  owner: q2d2
+  revisions:
+  - 6c2c8696456f
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__demux__summarize
+  owner: q2d2
+  revisions:
+  - d8a9f74f1a6d
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__adonis
+  owner: q2d2
+  revisions:
+  - 82f9bc0feff3
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__alpha
+  owner: q2d2
+  revisions:
+  - 97e9b0b0aeae
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__alpha_correlation
+  owner: q2d2
+  revisions:
+  - 5850f79a2b9f
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__alpha_group_significance
+  owner: q2d2
+  revisions:
+  - b7b5dc5a067b
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__alpha_phylogenetic
+  owner: q2d2
+  revisions:
+  - fbf59d034371
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__alpha_rarefaction
+  owner: q2d2
+  revisions:
+  - 97cb20f77d50
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__beta
+  owner: q2d2
+  revisions:
+  - f5026cf3e156
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__beta_correlation
+  owner: q2d2
+  revisions:
+  - ea97592533bb
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__beta_group_significance
+  owner: q2d2
+  revisions:
+  - 2df83b20af3f
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__beta_phylogenetic
+  owner: q2d2
+  revisions:
+  - 26534bb91445
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__beta_rarefaction
+  owner: q2d2
+  revisions:
+  - a5b96ea48d79
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__bioenv
+  owner: q2d2
+  revisions:
+  - 0fb37e0413d6
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__core_metrics
+  owner: q2d2
+  revisions:
+  - 9602903a0fbd
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__core_metrics_phylogenetic
+  owner: q2d2
+  revisions:
+  - 9d29f6a334e5
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__filter_distance_matrix
+  owner: q2d2
+  revisions:
+  - a53b321e6821
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__mantel
+  owner: q2d2
+  revisions:
+  - '196948449667'
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__pcoa
+  owner: q2d2
+  revisions:
+  - 9f6dfa1155c4
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__pcoa_biplot
+  owner: q2d2
+  revisions:
+  - 0b649d0fe617
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__procrustes_analysis
+  owner: q2d2
+  revisions:
+  - fe144b0df710
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__tsne
+  owner: q2d2
+  revisions:
+  - 70d6cf1e8db0
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity__umap
+  owner: q2d2
+  revisions:
+  - 21c17986c882
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity_lib__alpha_passthrough
+  owner: q2d2
+  revisions:
+  - 98ae2621b590
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity_lib__beta_passthrough
+  owner: q2d2
+  revisions:
+  - 38a55b074008
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity_lib__beta_phylogenetic_meta_passthrough
+  owner: q2d2
+  revisions:
+  - 1fe13f74d48a
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity_lib__beta_phylogenetic_passthrough
+  owner: q2d2
+  revisions:
+  - fcbeb4dc4b81
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity_lib__bray_curtis
+  owner: q2d2
+  revisions:
+  - a1422e558f73
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity_lib__faith_pd
+  owner: q2d2
+  revisions:
+  - 1142e83c6ae3
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity_lib__jaccard
+  owner: q2d2
+  revisions:
+  - cf5fc36069f5
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity_lib__observed_features
+  owner: q2d2
+  revisions:
+  - f740751c2439
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity_lib__pielou_evenness
+  owner: q2d2
+  revisions:
+  - 02d2141ff634
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity_lib__shannon_entropy
+  owner: q2d2
+  revisions:
+  - 63d2b15ad101
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity_lib__unweighted_unifrac
+  owner: q2d2
+  revisions:
+  - 89423965acba
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__diversity_lib__weighted_unifrac
+  owner: q2d2
+  revisions:
+  - 0e3cc7583efc
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__emperor__biplot
+  owner: q2d2
+  revisions:
+  - c7d25d15856f
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__emperor__plot
+  owner: q2d2
+  revisions:
+  - bc3a80afa08d
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__emperor__procrustes_plot
+  owner: q2d2
+  revisions:
+  - ec2a0e6d9baf
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_classifier__blast
+  owner: q2d2
+  revisions:
+  - 778c23c7bcf3
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_classifier__classify_consensus_blast
+  owner: q2d2
+  revisions:
+  - 8f8f6d3d2304
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_classifier__classify_consensus_vsearch
+  owner: q2d2
+  revisions:
+  - f82f2dbf0c04
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_classifier__classify_hybrid_vsearch_sklearn
+  owner: q2d2
+  revisions:
+  - abdf08c37b16
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_classifier__classify_sklearn
+  owner: q2d2
+  revisions:
+  - 8aa82af30760
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_classifier__extract_reads
+  owner: q2d2
+  revisions:
+  - f3b56adfed5f
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_classifier__find_consensus_annotation
+  owner: q2d2
+  revisions:
+  - 44246091f51f
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_classifier__fit_classifier_naive_bayes
+  owner: q2d2
+  revisions:
+  - e0aebbd112a4
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_classifier__fit_classifier_sklearn
+  owner: q2d2
+  revisions:
+  - 651c5518951f
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_classifier__vsearch_global
+  owner: q2d2
+  revisions:
+  - c7bde9e4638d
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_table__core_features
+  owner: q2d2
+  revisions:
+  - 13e8049936ee
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_table__filter_features
+  owner: q2d2
+  revisions:
+  - b2df7f8e4a07
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_table__filter_features_conditionally
+  owner: q2d2
+  revisions:
+  - 78538c1b0993
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_table__filter_samples
+  owner: q2d2
+  revisions:
+  - 540707a41f82
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_table__filter_seqs
+  owner: q2d2
+  revisions:
+  - fd3798589de0
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_table__group
+  owner: q2d2
+  revisions:
+  - a27ceaf4cfc2
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_table__heatmap
+  owner: q2d2
+  revisions:
+  - c087d23bc043
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_table__merge
+  owner: q2d2
+  revisions:
+  - 4c2751c8cc0d
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_table__merge_seqs
+  owner: q2d2
+  revisions:
+  - 9b95556df0f4
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_table__merge_taxa
+  owner: q2d2
+  revisions:
+  - a0c16a5250e4
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_table__presence_absence
+  owner: q2d2
+  revisions:
+  - aa33dec8fd70
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_table__rarefy
+  owner: q2d2
+  revisions:
+  - 77dce1a45822
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_table__relative_frequency
+  owner: q2d2
+  revisions:
+  - 580e1edc91d7
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_table__rename_ids
+  owner: q2d2
+  revisions:
+  - a213286d3a38
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_table__subsample
+  owner: q2d2
+  revisions:
+  - 649a75b79784
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_table__summarize
+  owner: q2d2
+  revisions:
+  - 365ce7a8e641
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_table__tabulate_seqs
+  owner: q2d2
+  revisions:
+  - 6d5cd7bcc0d0
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__feature_table__transpose
+  owner: q2d2
+  revisions:
+  - 70629120ae6c
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__fragment_insertion__classify_otus_experimental
+  owner: q2d2
+  revisions:
+  - 52cffcc84c14
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__fragment_insertion__filter_features
+  owner: q2d2
+  revisions:
+  - 2fe92e997c9a
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__fragment_insertion__sepp
+  owner: q2d2
+  revisions:
+  - 2fa85eae206e
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__gneiss__assign_ids
+  owner: q2d2
+  revisions:
+  - 3b50918cb7ec
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__gneiss__correlation_clustering
+  owner: q2d2
+  revisions:
+  - ca5a3976d699
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__gneiss__dendrogram_heatmap
+  owner: q2d2
+  revisions:
+  - 78bd3306c2d5
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__gneiss__gradient_clustering
+  owner: q2d2
+  revisions:
+  - 76fb7a319e4f
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__gneiss__ilr_hierarchical
+  owner: q2d2
+  revisions:
+  - d0feca181800
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__gneiss__ilr_phylogenetic
+  owner: q2d2
+  revisions:
+  - 742e0648a108
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__gneiss__ilr_phylogenetic_differential
+  owner: q2d2
+  revisions:
+  - 9dedc5b9b732
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__gneiss__ilr_phylogenetic_ordination
+  owner: q2d2
+  revisions:
+  - f55de040b84c
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__longitudinal__anova
+  owner: q2d2
+  revisions:
+  - c32b6054c7d4
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__longitudinal__feature_volatility
+  owner: q2d2
+  revisions:
+  - ba818c170b06
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__longitudinal__first_differences
+  owner: q2d2
+  revisions:
+  - 0019d6fb2df8
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__longitudinal__first_distances
+  owner: q2d2
+  revisions:
+  - 607a63ad9e92
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__longitudinal__linear_mixed_effects
+  owner: q2d2
+  revisions:
+  - 6253ca844c62
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__longitudinal__maturity_index
+  owner: q2d2
+  revisions:
+  - 65eb20bd61f1
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__longitudinal__nmit
+  owner: q2d2
+  revisions:
+  - 87412f607999
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__longitudinal__pairwise_differences
+  owner: q2d2
+  revisions:
+  - b56e60e6c6e0
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__longitudinal__pairwise_distances
+  owner: q2d2
+  revisions:
+  - 7799afde3e88
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__longitudinal__plot_feature_volatility
+  owner: q2d2
+  revisions:
+  - 11730a5ad81b
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__longitudinal__volatility
+  owner: q2d2
+  revisions:
+  - 0e3d1b6523e2
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__metadata__distance_matrix
+  owner: q2d2
+  revisions:
+  - 8a43985a8f35
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__metadata__shuffle_groups
+  owner: q2d2
+  revisions:
+  - 99fb88cf7a12
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__metadata__tabulate
+  owner: q2d2
+  revisions:
+  - d6e1b976c373
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__phylogeny__align_to_tree_mafft_fasttree
+  owner: q2d2
+  revisions:
+  - 2a9461620d5e
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__phylogeny__align_to_tree_mafft_iqtree
+  owner: q2d2
+  revisions:
+  - 25daaf299138
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__phylogeny__align_to_tree_mafft_raxml
+  owner: q2d2
+  revisions:
+  - 9af151e32f0e
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__phylogeny__fasttree
+  owner: q2d2
+  revisions:
+  - 977e2ec8beb0
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__phylogeny__filter_table
+  owner: q2d2
+  revisions:
+  - 05d29a3294de
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__phylogeny__filter_tree
+  owner: q2d2
+  revisions:
+  - 97716f0bd25b
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__phylogeny__iqtree
+  owner: q2d2
+  revisions:
+  - 2f898b3531ee
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__phylogeny__iqtree_ultrafast_bootstrap
+  owner: q2d2
+  revisions:
+  - adccaaf33660
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__phylogeny__midpoint_root
+  owner: q2d2
+  revisions:
+  - f4f3c556d4bd
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__phylogeny__raxml
+  owner: q2d2
+  revisions:
+  - 2ff23f0ed1ba
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__phylogeny__raxml_rapid_bootstrap
+  owner: q2d2
+  revisions:
+  - 1de3a5758b8c
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__phylogeny__robinson_foulds
+  owner: q2d2
+  revisions:
+  - 462ba4008e3c
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__quality_control__bowtie2_build
+  owner: q2d2
+  revisions:
+  - ea81dc3914f8
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__quality_control__evaluate_composition
+  owner: q2d2
+  revisions:
+  - 69c5dfffb92f
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__quality_control__evaluate_seqs
+  owner: q2d2
+  revisions:
+  - 4bb288dbd04c
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__quality_control__evaluate_taxonomy
+  owner: q2d2
+  revisions:
+  - 13f0559220c2
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__quality_control__exclude_seqs
+  owner: q2d2
+  revisions:
+  - cf4229cd0a05
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__quality_control__filter_reads
+  owner: q2d2
+  revisions:
+  - 08d08d22d92b
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__quality_filter__q_score
+  owner: q2d2
+  revisions:
+  - 090ca1116927
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__sample_classifier__classify_samples
+  owner: q2d2
+  revisions:
+  - e72fb1ecbadc
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__sample_classifier__classify_samples_from_dist
+  owner: q2d2
+  revisions:
+  - aeb2a22548a5
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__sample_classifier__classify_samples_ncv
+  owner: q2d2
+  revisions:
+  - 23c5522fa836
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__sample_classifier__confusion_matrix
+  owner: q2d2
+  revisions:
+  - e0a29b2a35a8
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__sample_classifier__fit_classifier
+  owner: q2d2
+  revisions:
+  - f31f3c575d7e
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__sample_classifier__fit_regressor
+  owner: q2d2
+  revisions:
+  - d0708941b20b
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__sample_classifier__heatmap
+  owner: q2d2
+  revisions:
+  - 5ceed9008edb
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__sample_classifier__metatable
+  owner: q2d2
+  revisions:
+  - 30cdc8cb01d0
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__sample_classifier__predict_classification
+  owner: q2d2
+  revisions:
+  - d4dd156970fc
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__sample_classifier__predict_regression
+  owner: q2d2
+  revisions:
+  - f7c33b0adf29
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__sample_classifier__regress_samples
+  owner: q2d2
+  revisions:
+  - 09981e91ac53
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__sample_classifier__regress_samples_ncv
+  owner: q2d2
+  revisions:
+  - e6d86f57fe1a
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__sample_classifier__scatterplot
+  owner: q2d2
+  revisions:
+  - 195348fe70ef
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__sample_classifier__split_table
+  owner: q2d2
+  revisions:
+  - a80604576ca2
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__sample_classifier__summarize
+  owner: q2d2
+  revisions:
+  - d2cd82660ab6
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__taxa__barplot
+  owner: q2d2
+  revisions:
+  - 124673b2e9e7
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__taxa__collapse
+  owner: q2d2
+  revisions:
+  - 16e425d54e64
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__taxa__filter_seqs
+  owner: q2d2
+  revisions:
+  - 2e3425c03486
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__taxa__filter_table
+  owner: q2d2
+  revisions:
+  - 8415c3cbedb6
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__vsearch__cluster_features_closed_reference
+  owner: q2d2
+  revisions:
+  - 99f3bb0084fe
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__vsearch__cluster_features_de_novo
+  owner: q2d2
+  revisions:
+  - 397c1be954c2
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__vsearch__cluster_features_open_reference
+  owner: q2d2
+  revisions:
+  - d62c0266f393
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__vsearch__dereplicate_sequences
+  owner: q2d2
+  revisions:
+  - 4fb2b5e9beba
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__vsearch__fastq_stats
+  owner: q2d2
+  revisions:
+  - 55e1a7184edd
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__vsearch__merge_pairs
+  owner: q2d2
+  revisions:
+  - f455181d916d
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__vsearch__uchime_denovo
+  owner: q2d2
+  revisions:
+  - 2ecd644cdfcf
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2__vsearch__uchime_ref
+  owner: q2d2
+  revisions:
+  - 7dbbd990440e
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2_core__tools__export
+  owner: q2d2
+  revisions:
+  - ddff0f6d5740
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2
+- name: qiime2_core__tools__import
+  owner: q2d2
+  revisions:
+  - 18c6b2b6740f
+  tool_panel_section_id: qiime2
+  tool_panel_section_label: QIIME2


### PR DESCRIPTION
add qiime2 tools to Main into new section `QIIME2` (same as on eu)

list is the same as in https://github.com/usegalaxy-eu/usegalaxy-eu-tools/blob/eb1c8dde37973f586ff2a62941d85d306fe3b2e2/tools_q2d2.yaml

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
