### PR TITLE
remove revision of iuc/purge_dups that does not exist from main

### DIFF
--- a/usegalaxy.org/assembly.yml.lock
+++ b/usegalaxy.org/assembly.yml.lock
@@ -228,7 +228,6 @@ tools:
   - 29151e779524
   - 76d4cbefff85
   - a315c25dc813
-  - cf13a1e03e5b
   - e9bd16ba5ebd
   tool_panel_section_id: assembly
   tool_panel_section_label: Assembly


### PR DESCRIPTION
error from jenkins:

* Error installing a repository (after 0:00:00.102918 seconds)! Name: purge_dups,owner: iuc, revision: cf13a1e03e5b, error: {"err_msg": "No information is available for the requested repository revision.\nOne or more of the following parameter values is likely invalid: \ntool_shed_url: https://toolshed.g2.bx.psu.edu/\nname: purge_dups\nowner: iuc\nchangeset_revision: cf13a1e03e5b\n", "err_code": 400008}

TODO: Please replace this header with a description of your pull request.

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
