### PR TITLE
Switch to fixed version of pretext graph

### DIFF
--- a/usegalaxy.org/assembly.yml.lock
+++ b/usegalaxy.org/assembly.yml.lock
@@ -316,7 +316,7 @@ tools:
 - name: pretext_graph
   owner: iuc
   revisions:
-  - 75b4a2298714
+  - eca7d3a0c5f2
   tool_panel_section_id: assembly
   tool_panel_section_label: Assembly
 - name: gfastats

--- a/usegalaxy.org/assembly.yml.lock
+++ b/usegalaxy.org/assembly.yml.lock
@@ -316,6 +316,7 @@ tools:
 - name: pretext_graph
   owner: iuc
   revisions:
+  - 75b4a2298714
   - eca7d3a0c5f2
   tool_panel_section_id: assembly
   tool_panel_section_label: Assembly


### PR DESCRIPTION
Found an error in pretext graph's wrapper, fixed but didn't update the version, so switching out for fixed wrapper
## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
