### PR TITLE
Add Tasmanian Mismatch tool to usegalaxy.org

### DIFF
--- a/usegalaxy.org/evolution.yml
+++ b/usegalaxy.org/evolution.yml
@@ -10,3 +10,5 @@ tools:
   owner: iuc
 - name: tn93_readreduce
   owner: iuc
+- name: tasmanian_mismatch
+  owner: iuc

--- a/usegalaxy.org/evolution.yml.lock
+++ b/usegalaxy.org/evolution.yml.lock
@@ -35,3 +35,9 @@ tools:
   - bdaadfd0c843
   tool_panel_section_id: evolution
   tool_panel_section_label: Evolution
+- name: tasmanian_mismatch
+  owner: iuc
+  revisions:
+  - b15fbf90db53
+  tool_panel_section_id: evolution
+  tool_panel_section_label: Evolution


### PR DESCRIPTION
Adds the Tasmanian Mismatch tool to usegalaxy.org

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
