### PR TITLE
Add brew3r_r

### DIFF
--- a/usegalaxy.org/rna_seq.yml
+++ b/usegalaxy.org/rna_seq.yml
@@ -118,3 +118,5 @@ tools:
   owner: rnateam
 - name: isoformswitchanalyzer
   owner: iuc
+- name: brew3r_r
+  owner: iuc

--- a/usegalaxy.org/rna_seq.yml.lock
+++ b/usegalaxy.org/rna_seq.yml.lock
@@ -522,3 +522,9 @@ tools:
   - b3f292d9f35d
   tool_panel_section_id: rna_seq
   tool_panel_section_label: RNA-seq
+- name: brew3r_r
+  owner: iuc
+  revisions:
+  - 928a52b5c938
+  tool_panel_section_id: rna_seq
+  tool_panel_section_label: RNA-seq


### PR DESCRIPTION
I would like to install brew3r_r on usegalaxy.org. This is a tool needed for [BREW3R](https://github.com/lldelisle/BREW3R) that will be presented at GCC2024.

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
