### PR TITLE
Add blobtoolkit to org

### DIFF
--- a/usegalaxy.org/assembly.yml
+++ b/usegalaxy.org/assembly.yml
@@ -1,5 +1,7 @@
 tool_panel_section_label: Assembly
 tools:
+- name: blobtoolkit
+  owner: bgruening
 - name: unicycler
   owner: iuc
 - name: quast

--- a/usegalaxy.org/assembly.yml.lock
+++ b/usegalaxy.org/assembly.yml.lock
@@ -3,6 +3,12 @@ install_resolver_dependencies: false
 install_tool_dependencies: false
 tool_panel_section_label: Assembly
 tools:
+- name: blobtoolkit
+  owner: bgruening
+  revisions:
+  - 53dd00a4ab68
+  tool_panel_section_id: assembly
+  tool_panel_section_label: Assembly
 - name: unicycler
   owner: iuc
   revisions:


### PR DESCRIPTION
Already available on .eu via bgruening toolshed.

I would also like to include the interactive tool to visualise blobtool runs, but I can't find this in the toolshed:

https://usegalaxy.eu/root?tool_id=interactive_tool_blobtoolkit

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
