### PR TITLE
Add Validate FASTA Database tool

### DIFF
--- a/usegalaxy.org/proteomics.yml
+++ b/usegalaxy.org/proteomics.yml
@@ -36,3 +36,5 @@ tools:
   owner: iuc
 - name: colabfold_alphafold
   owner: iuc
+- name: validate_fasta_database
+  owner: galaxyp

--- a/usegalaxy.org/proteomics.yml.lock
+++ b/usegalaxy.org/proteomics.yml.lock
@@ -143,3 +143,9 @@ tools:
   - 9d65257c56de
   tool_panel_section_id: proteomics
   tool_panel_section_label: Proteomics
+- name: validate_fasta_database
+  owner: galaxyp
+  revisions:
+  - 9c246c2e24ad
+  tool_panel_section_id: proteomics
+  tool_panel_section_label: Proteomics


### PR DESCRIPTION
Adds the **Validate FASTA Database** tool from GalaxyP.

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
