### PR TITLE
Add FragPipe Tool

### DIFF
--- a/usegalaxy.org/proteomics.yml
+++ b/usegalaxy.org/proteomics.yml
@@ -36,3 +36,5 @@ tools:
   owner: iuc
 - name: colabfold_alphafold
   owner: iuc
+- name: fragpipe
+  owner: galaxyp

--- a/usegalaxy.org/proteomics.yml.lock
+++ b/usegalaxy.org/proteomics.yml.lock
@@ -143,3 +143,9 @@ tools:
   - 9d65257c56de
   tool_panel_section_id: proteomics
   tool_panel_section_label: Proteomics
+- name: fragpipe
+  owner: galaxyp
+  revisions:
+  - ef46866326ef
+  tool_panel_section_id: proteomics
+  tool_panel_section_label: Proteomics


### PR DESCRIPTION
Adds the **FragPipe** tool from GalaxyP.

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
