### PR TITLE
Adjust tool data path to point to expected cvmfs location

### DIFF
--- a/.ci/jenkins.sh
+++ b/.ci/jenkins.sh
@@ -516,7 +516,7 @@ function run_cloudve_galaxy() {
         -e "GALAXY_CONFIG_OVERRIDE_SHED_TOOL_DATA_TABLE_CONFIG=${SHED_TOOL_DATA_TABLE_CONFIG}" \
         -e "GALAXY_CONFIG_OVERRIDE_SHED_DATA_MANAGER_CONFIG_FILE=${SHED_DATA_MANAGER_CONFIG}" \
         -e "GALAXY_CONFIG_OVERRIDE_INTERACTIVETOOLS_ENABLE=true" \
-        -e "GALAXY_CONFIG_TOOL_DATA_PATH=/tmp/tool-data" \
+        -e "GALAXY_CONFIG_TOOL_DATA_PATH=/cvmfs/cloud.galaxyproject.org/tools" \
         -e "GALAXY_CONFIG_INSTALL_DATABASE_CONNECTION=sqlite:///${INSTALL_DATABASE}" \
         -e "GALAXY_CONFIG_MASTER_API_KEY=${API_KEY:=deadbeef}" \
         -e "GALAXY_CONFIG_FILE=/galaxy/server/lib/galaxy/config/sample/galaxy.yml.sample" \

--- a/cloud/assembly.yml.lock
+++ b/cloud/assembly.yml.lock
@@ -35,6 +35,7 @@ tools:
   owner: bgruening
   revisions:
   - 3ef480892a9f
+  - 764f2516d837
   - f4a3eff8ab85
   tool_panel_section_id: assembly
   tool_panel_section_label: Assembly
@@ -42,5 +43,6 @@ tools:
   owner: iuc
   revisions:
   - 72472698a2df
+  - a3b35edea53a
   tool_panel_section_id: assembly
   tool_panel_section_label: Assembly

--- a/cloud/data_managers.yml.lock
+++ b/cloud/data_managers.yml.lock
@@ -109,6 +109,7 @@ tools:
   revisions:
   - 13851aefa67a
   - 1e34d2e3d285
+  - 201eff2131d6
   - 539b008cfe1c
   - 8c533e19b697
   - 90b4d4f0a3a4

--- a/cloud/fasta_fastq.yml.lock
+++ b/cloud/fasta_fastq.yml.lock
@@ -73,6 +73,7 @@ tools:
 - name: umi_tools_count
   owner: iuc
   revisions:
+  - 437d5c72f2e3
   - 71ad4a56c40c
   - 8250ea3a1501
   - a535cf1e5da4
@@ -82,6 +83,7 @@ tools:
 - name: umi_tools_extract
   owner: iuc
   revisions:
+  - 14ba4366aca4
   - 6a675c3aa610
   - 7a7e33d28f62
   - 99aea37a7ff7

--- a/cloud/fastq_quality_control.yml.lock
+++ b/cloud/fastq_quality_control.yml.lock
@@ -10,6 +10,7 @@ tools:
   - 5e33b465d8d5
   - 75c93c70d094
   - 9a913cdee30e
+  - a7e081ceb76a
   - abfd8a6544d7
   - df99138d2776
   - f7e2f1eb3a16
@@ -19,6 +20,7 @@ tools:
   owner: iuc
   revisions:
   - 65b93b623c77
+  - a626e8c0e1ba
   - d60c3f704da0
   - dbf9c561ef29
   - dbfc505896e9

--- a/cloud/graph_display_data.yml.lock
+++ b/cloud/graph_display_data.yml.lock
@@ -28,6 +28,7 @@ tools:
   owner: iuc
   revisions:
   - 2f557f6abbfb
+  - 5e08a1e22dbc
   - 73b8cb5bddcd
   - 83c573f2e73c
   tool_panel_section_id: graph_display_data
@@ -43,6 +44,7 @@ tools:
   owner: iuc
   revisions:
   - 374e9062d874
+  - 48b42ee61bc5
   - 4955e9bb96d1
   - 51c6ccaace7e
   - 53460afd5115

--- a/cloud/mapping.yml.lock
+++ b/cloud/mapping.yml.lock
@@ -44,6 +44,7 @@ tools:
   revisions:
   - 2055c2667eb3
   - 4014de1b6daf
+  - 53255f6eecfc
   - 980d2a2e1180
   - b0f2be869d6d
   - c772497b2c32
@@ -52,6 +53,7 @@ tools:
 - name: rna_starsolo
   owner: iuc
   revisions:
+  - 381a32c51141
   - 42ce70172b72
   - 45795f582ae9
   - 79b885ce78d7

--- a/cloud/multiple_alignments.yml.lock
+++ b/cloud/multiple_alignments.yml.lock
@@ -8,11 +8,13 @@ tools:
   revisions:
   - 636b049e6141
   - 7cd7a55a678d
+  - fcad5e09a99d
   tool_panel_section_id: multiple_alignments
   tool_panel_section_label: Multiple Alignments
 - name: mummer_mummerplot
   owner: iuc
   revisions:
+  - 0c37cb9102d0
   - ebe3b0f84de9
   - fb43e8887350
   tool_panel_section_id: multiple_alignments
@@ -22,11 +24,13 @@ tools:
   revisions:
   - 959c1f8dae95
   - cf3c9489c088
+  - e832875e5d5a
   tool_panel_section_id: multiple_alignments
   tool_panel_section_label: Multiple Alignments
 - name: mummer_dnadiff
   owner: iuc
   revisions:
+  - 4122b2fb7964
   - 5561a1193611
   - 60698466facd
   tool_panel_section_id: multiple_alignments
@@ -34,6 +38,7 @@ tools:
 - name: mummer_mummer
   owner: iuc
   revisions:
+  - 2f4d9668d3b4
   - 48823c9635a4
   - 57f042937ba7
   tool_panel_section_id: multiple_alignments
@@ -41,6 +46,7 @@ tools:
 - name: mummer_delta_filter
   owner: iuc
   revisions:
+  - 2ab1e0e1c32e
   - b3acbb3a6af0
   - e8fdceffea4c
   tool_panel_section_id: multiple_alignments

--- a/cloud/nanopore.yml.lock
+++ b/cloud/nanopore.yml.lock
@@ -16,6 +16,7 @@ tools:
   - 1f0769f0b56b
   - 3e4f8642c77e
   - 3ee0ef312022
+  - cd11366d92cf
   tool_panel_section_id: nanopore
   tool_panel_section_label: Nanopore
 - name: medaka_consensus_pipeline
@@ -63,6 +64,7 @@ tools:
 - name: poretools_occupancy
   owner: iuc
   revisions:
+  - 0433aad600e9
   - 338d15b8d6fb
   tool_panel_section_id: nanopore
   tool_panel_section_label: Nanopore

--- a/cloud/rna_seq.yml.lock
+++ b/cloud/rna_seq.yml.lock
@@ -76,6 +76,7 @@ tools:
   - 1759d845181e
   - 1b851f87fbe0
   - 38b6d12edc68
+  - 5dbff3a5845a
   - f3a5f075498f
   - f9d49f5cb597
   tool_panel_section_id: rna_seq
@@ -128,6 +129,7 @@ tools:
 - name: dexseq
   owner: iuc
   revisions:
+  - 74ec758e63a4
   - 9a7c5b6d8f1e
   tool_panel_section_id: rna_seq
   tool_panel_section_label: RNA-seq

--- a/cloud/single_cell.yml.lock
+++ b/cloud/single_cell.yml.lock
@@ -49,6 +49,7 @@ tools:
 - name: anndata_import
   owner: iuc
   revisions:
+  - 13cf83ced60c
   - 55e35e9203cf
   - 93dd15e13e6a
   - d330b3082107
@@ -60,6 +61,7 @@ tools:
   revisions:
   - 0cb889db0910
   - 707023fa62fe
+  - 83609ef746e9
   - cfaf5a405371
   - e1c3c2f2a834
   tool_panel_section_id: single_cell
@@ -70,6 +72,7 @@ tools:
   - 3d748954434b
   - 7e8c677a7b71
   - 9bd945a03d7b
+  - d1e49c3c0aa2
   - ed4996a16f7f
   tool_panel_section_id: single_cell
   tool_panel_section_label: Single-cell
@@ -85,6 +88,7 @@ tools:
   revisions:
   - 0bf7fddf90c7
   - 286a24ac079c
+  - 33c0081e16c6
   - 688357ad5e61
   - 6f0d0c784f09
   - ee98d611afc6
@@ -95,6 +99,7 @@ tools:
   revisions:
   - 05631436cdf1
   - 0f1aaff9b22d
+  - a7b951572609
   - e98619de2776
   tool_panel_section_id: single_cell
   tool_panel_section_label: Single-cell
@@ -248,6 +253,7 @@ tools:
 - name: scanpy_filter
   owner: iuc
   revisions:
+  - 5b3c1679d29b
   - 64388be6d510
   - 72a6bebab2a5
   - b409c2486353

--- a/cloud/text_manipulation.yml.lock
+++ b/cloud/text_manipulation.yml.lock
@@ -133,6 +133,7 @@ tools:
 - name: diff
   owner: bgruening
   revisions:
+  - 10ef1bf99074
   - 156d0908e232
   tool_panel_section_id: text_manipulation
   tool_panel_section_label: Text Manipulation

--- a/cloud/variant_calling.yml.lock
+++ b/cloud/variant_calling.yml.lock
@@ -73,6 +73,7 @@ tools:
   - 68693743661e
   - 74aebe30fb52
   - 9473cd297a76
+  - c7275bd8b4d6
   - ca2b512e8d7c
   - cfcf33df7fc0
   tool_panel_section_id: variant_calling
@@ -89,6 +90,7 @@ tools:
   revisions:
   - 43fffeed243f
   - 93c4b04a0769
+  - ceff2f6a5368
   tool_panel_section_id: variant_calling
   tool_panel_section_label: Variant Calling
 - name: jasminesv
@@ -104,6 +106,7 @@ tools:
   - 68693743661e
   - 74aebe30fb52
   - 9473cd297a76
+  - c7275bd8b4d6
   - ca2b512e8d7c
   - cfcf33df7fc0
   tool_panel_section_id: variant_calling


### PR DESCRIPTION
The generated conf points to /tmp/tool-data instead of /cvmfs:
```
#### diff of shed_tool_data_table_conf.xml
+ eval diff -u /data/jenkins/workspace/usegalaxy-tools/1760/lower/config/shed_tool_data_table_conf.xml /data/jenkins/workspace/usegalaxy-tools/1760/mount/config/shed_tool_data_table_conf.xml
++ diff -u /data/jenkins/workspace/usegalaxy-tools/1760/lower/config/shed_tool_data_table_conf.xml /data/jenkins/workspace/usegalaxy-tools/1760/mount/config/shed_tool_data_table_conf.xml
--- /data/jenkins/workspace/usegalaxy-tools/1760/lower/config/shed_tool_data_table_conf.xml	2024-11-14 19:49:04.000000000 +0000
+++ /data/jenkins/workspace/usegalaxy-tools/1760/mount/config/shed_tool_data_table_conf.xml	2025-01-22 18:13:46.994473615 +0000
@@ -2320,4 +2320,644 @@
             <installed_changeset_revision>43fffeed243f</installed_changeset_revision>
         </tool_shed_repository>
     </table>
+    <table name="all_fasta" comment_char="#">
+        <columns>value, dbkey, name, path</columns>
+        <file path="/tmp/tool-data/toolshed.g2.bx.psu.edu/repos/devteam/data_manager_fetch_genome_dbkeys_all_fasta/4a82d1157b14/all_fasta.loc"/>
+        <tool_shed_repository>
+            <tool_shed>toolshed.g2.bx.psu.edu</tool_shed>
+            <repository_name>data_manager_fetch_genome_dbkeys_all_fasta</repository_name>
+            <repository_owner>devteam</repository_owner>
+            <installed_changeset_revision>4a82d1157b14</installed_changeset_revision>
+        </tool_shed_repository>
+    </table>
+   ...
```

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
