### PR TITLE
[cloud] Update GALAXY_CONFIG_TOOL_DATA_PATH

### DIFF
--- a/.ci/jenkins.sh
+++ b/.ci/jenkins.sh
@@ -526,7 +526,7 @@ function run_cloudve_galaxy() {
         -v "${WORKDIR}/tool_sheds_conf.xml:/tool_sheds_conf.xml" \
         -v "${WORKDIR}/condarc:${CONDARC_MOUNT_PATH}" \
         -v "${GALAXY_DATABASE_TMPDIR}:/galaxy/server/database" \
-        -v "/tmp/tool-data:/galaxy/server/config/mutable" \
+        -v "${GALAXY_DATABASE_TMPDIR}:/galaxy/server/config" \
         --workdir /galaxy/server \
         "$GALAXY_DOCKER_IMAGE" ./.venv/bin/gunicorn 'galaxy.webapps.galaxy.fast_factory:factory\(\)' --timeout 300 --pythonpath lib -k galaxy.webapps.galaxy.workers.Worker -b 0.0.0.0:8080
         #"$GALAXY_DOCKER_IMAGE" ./.venv/bin/uwsgi --yaml config/galaxy.yml

--- a/.ci/jenkins.sh
+++ b/.ci/jenkins.sh
@@ -526,6 +526,7 @@ function run_cloudve_galaxy() {
         -v "${WORKDIR}/tool_sheds_conf.xml:/tool_sheds_conf.xml" \
         -v "${WORKDIR}/condarc:${CONDARC_MOUNT_PATH}" \
         -v "${GALAXY_DATABASE_TMPDIR}:/galaxy/server/database" \
+        -v "/tmp/tool-data:/galaxy/server/config/mutable" \
         --workdir /galaxy/server \
         "$GALAXY_DOCKER_IMAGE" ./.venv/bin/gunicorn 'galaxy.webapps.galaxy.fast_factory:factory\(\)' --timeout 300 --pythonpath lib -k galaxy.webapps.galaxy.workers.Worker -b 0.0.0.0:8080
         #"$GALAXY_DOCKER_IMAGE" ./.venv/bin/uwsgi --yaml config/galaxy.yml

--- a/.ci/jenkins.sh
+++ b/.ci/jenkins.sh
@@ -516,7 +516,7 @@ function run_cloudve_galaxy() {
         -e "GALAXY_CONFIG_OVERRIDE_SHED_TOOL_DATA_TABLE_CONFIG=${SHED_TOOL_DATA_TABLE_CONFIG}" \
         -e "GALAXY_CONFIG_OVERRIDE_SHED_DATA_MANAGER_CONFIG_FILE=${SHED_DATA_MANAGER_CONFIG}" \
         -e "GALAXY_CONFIG_OVERRIDE_INTERACTIVETOOLS_ENABLE=true" \
-        -e "GALAXY_CONFIG_TOOL_DATA_PATH=/tmp/tool-data" \
+        -e "GALAXY_CONFIG_TOOL_DATA_PATH=/galaxy/server/config/mutable" \
         -e "GALAXY_CONFIG_INSTALL_DATABASE_CONNECTION=sqlite:///${INSTALL_DATABASE}" \
         -e "GALAXY_CONFIG_MASTER_API_KEY=${API_KEY:=deadbeef}" \
         -e "GALAXY_CONFIG_FILE=/galaxy/server/lib/galaxy/config/sample/galaxy.yml.sample" \

--- a/cloud/data_managers.yml
+++ b/cloud/data_managers.yml
@@ -36,3 +36,5 @@ tools:
   owner: iuc
 - name: data_manager_mapseq
   owner: iuc
+- name: data_manager_fetch_plasmidfinder
+  owner: iuc

--- a/cloud/data_managers.yml.lock
+++ b/cloud/data_managers.yml.lock
@@ -133,3 +133,9 @@ tools:
   - dbf2735e8480
   tool_panel_section_id: data_managers
   tool_panel_section_label: Data Managers
+- name: data_manager_fetch_plasmidfinder
+  owner: iuc
+  revisions:
+  - 8a3955d56000
+  tool_panel_section_id: data_managers
+  tool_panel_section_label: Data Managers


### PR DESCRIPTION
Hopefully this will allow us to simply include `shed_tool_data_table_conf.xml` from CVFMS in the Galaxy Helm chart instead of shipping it with the chart, ensuring we have an in-sync config file with the pre-installed data managers.

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
