### PR TITLE
add tool : Tapscan

### DIFF
--- a/usegalaxy.org/annotation.yml
+++ b/usegalaxy.org/annotation.yml
@@ -144,3 +144,6 @@ tools:
   owner: genouest
 - name: omark
   owner: iuc
+- name: tapscan
+  owner: bgruening
+  

--- a/usegalaxy.org/annotation.yml.lock
+++ b/usegalaxy.org/annotation.yml.lock
@@ -587,3 +587,9 @@ tools:
   - ceb52582a5b1
   tool_panel_section_id: annotation
   tool_panel_section_label: Annotation
+- name: tapscan
+  owner: bgruening
+  revisions:
+  - c4f865bd101a
+  tool_panel_section_id: annotation
+  tool_panel_section_label: Annotation


### PR DESCRIPTION
Adding the TAPScan tool, which is available on the European server but not on the main Org server, is needed for GTA to be available on the org server.
Since TAPScan works based on domain detection and gene family assignment for protein sequences, I wasn’t sure which .yml file would be most appropriate. I’m happy to take suggestions if there's a better fit.

Thank you so much,
Deepti Varshney