### PR TITLE
add tabular_learner

### DIFF
--- a/usegalaxy.org/machine_learning.yml
+++ b/usegalaxy.org/machine_learning.yml
@@ -1,5 +1,7 @@
 tool_panel_section_label: Machine Learning
 tools:
+- name: tabular_learner
+  owner: goeckslab
 - name: pycaret_compare
   owner: goeckslab
 - name: pycaret_predict

--- a/usegalaxy.org/machine_learning.yml.lock
+++ b/usegalaxy.org/machine_learning.yml.lock
@@ -3,6 +3,12 @@ install_resolver_dependencies: false
 install_tool_dependencies: false
 tool_panel_section_label: Machine Learning
 tools:
+- name: tabular_learner
+  owner: goeckslab
+  revisions:
+  - 209b663a4f62
+  tool_panel_section_id: machine_learning
+  tool_panel_section_label: Machine Learning
 - name: pycaret_compare
   owner: goeckslab
   revisions:


### PR DESCRIPTION
We’ve renamed the tool ID from `pycaret_compare` (as already installed on usegalaxy.org) to `tabular_learner` to reflect our shift toward a dataset-type-oriented tool rather than a package-oriented one. We may later use packages such as `AutoGluon` to update `tabular_learner`, so renaming the tool ID now makes sense. We will deprecate `pycaret_compare` once `tabular_learner` is installed.

If it’s helpful for review, the code for `tabular_learner` is identical to that of `pycaret_compare`.

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
