### PR TITLE
Add more tools for analyzing virus/phage in metagenomics

### DIFF
--- a/usegalaxy.org/data_managers.yml
+++ b/usegalaxy.org/data_managers.yml
@@ -42,3 +42,7 @@ tools:
   owner: ufz
 - name: genomad_build_database
   owner: ufz
+- name: data_manager_defense_finder
+  owner: rplanel
+- name: iphop_build_database
+  owner: ufz

--- a/usegalaxy.org/data_managers.yml.lock
+++ b/usegalaxy.org/data_managers.yml.lock
@@ -152,3 +152,15 @@ tools:
   - 75abfb03b635
   tool_panel_section_id: data_managers
   tool_panel_section_label: Data Managers
+- name: data_manager_defense_finder
+  owner: rplanel
+  revisions:
+  - 502208b90cfe
+  tool_panel_section_id: data_managers
+  tool_panel_section_label: Data Managers
+- name: iphop_build_database
+  owner: ufz
+  revisions:
+  - 39dc692a9554
+  tool_panel_section_id: data_managers
+  tool_panel_section_label: Data Managers

--- a/usegalaxy.org/metagenomic_analysis.yml
+++ b/usegalaxy.org/metagenomic_analysis.yml
@@ -212,3 +212,9 @@ tools:
   owner: bgruening
 - name: sylph_profile
   owner: bgruening
+- name: phi_toolkit_report
+  owner: ufz
+- name: defense_finder
+  owner: rplanel
+- name: iphop_predict
+  owner: ufz

--- a/usegalaxy.org/metagenomic_analysis.yml
+++ b/usegalaxy.org/metagenomic_analysis.yml
@@ -216,9 +216,5 @@ tools:
   owner: ufz
 - name: defense_finder
   owner: rplanel
-- name: data_manager_defense_finder
-  owner: rplanel
 - name: iphop_predict
-  owner: ufz
-- name: iphop_build_database
   owner: ufz

--- a/usegalaxy.org/metagenomic_analysis.yml
+++ b/usegalaxy.org/metagenomic_analysis.yml
@@ -216,5 +216,9 @@ tools:
   owner: ufz
 - name: defense_finder
   owner: rplanel
+- name: data_manager_defense_finder
+  owner: rplanel
 - name: iphop_predict
+  owner: ufz
+- name: iphop_build_database
   owner: ufz

--- a/usegalaxy.org/metagenomic_analysis.yml.lock
+++ b/usegalaxy.org/metagenomic_analysis.yml.lock
@@ -893,3 +893,21 @@ tools:
   - 6c1ac7640090
   tool_panel_section_id: metagenomic_analysis
   tool_panel_section_label: Metagenomic Analysis
+- name: phi_toolkit_report
+  owner: ufz
+  revisions:
+  - 315c2ed31af1
+  tool_panel_section_id: metagenomic_analysis
+  tool_panel_section_label: Metagenomic Analysis
+- name: defense_finder
+  owner: rplanel
+  revisions:
+  - 71e221c4906c
+  tool_panel_section_id: metagenomic_analysis
+  tool_panel_section_label: Metagenomic Analysis
+- name: iphop_predict
+  owner: ufz
+  revisions:
+  - d357350b6da0
+  tool_panel_section_id: metagenomic_analysis
+  tool_panel_section_label: Metagenomic Analysis

--- a/usegalaxy.org/metagenomic_analysis.yml.lock
+++ b/usegalaxy.org/metagenomic_analysis.yml.lock
@@ -905,21 +905,9 @@ tools:
   - 71e221c4906c
   tool_panel_section_id: metagenomic_analysis
   tool_panel_section_label: Metagenomic Analysis
-- name: data_manager_defense_finder
-  owner: rplanel
-  revisions:
-  - 502208b90cfe
-  tool_panel_section_id: metagenomic_analysis
-  tool_panel_section_label: Metagenomic Analysis
 - name: iphop_predict
   owner: ufz
   revisions:
   - d357350b6da0
-  tool_panel_section_id: metagenomic_analysis
-  tool_panel_section_label: Metagenomic Analysis
-- name: iphop_build_database
-  owner: ufz
-  revisions:
-  - 39dc692a9554
   tool_panel_section_id: metagenomic_analysis
   tool_panel_section_label: Metagenomic Analysis

--- a/usegalaxy.org/metagenomic_analysis.yml.lock
+++ b/usegalaxy.org/metagenomic_analysis.yml.lock
@@ -905,9 +905,21 @@ tools:
   - 71e221c4906c
   tool_panel_section_id: metagenomic_analysis
   tool_panel_section_label: Metagenomic Analysis
+- name: data_manager_defense_finder
+  owner: rplanel
+  revisions:
+  - 502208b90cfe
+  tool_panel_section_id: metagenomic_analysis
+  tool_panel_section_label: Metagenomic Analysis
 - name: iphop_predict
   owner: ufz
   revisions:
   - d357350b6da0
+  tool_panel_section_id: metagenomic_analysis
+  tool_panel_section_label: Metagenomic Analysis
+- name: iphop_build_database
+  owner: ufz
+  revisions:
+  - 39dc692a9554
   tool_panel_section_id: metagenomic_analysis
   tool_panel_section_label: Metagenomic Analysis


### PR DESCRIPTION
- iphop_predict is already on usegalaxy.eu
- phi_toolkit_report and defense_finder have been tested on my instance with a workflow that I want to submit to IWC


## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
