### PR TITLE
Add Reactome CLI

### DIFF
--- a/usegalaxy.org/proteomics.yml
+++ b/usegalaxy.org/proteomics.yml
@@ -52,3 +52,5 @@ tools:
   owner: galaxyp
 - name: metanovo
   owner: galaxyp
+- name: reactome_cli
+  owner: paul_wolfe

--- a/usegalaxy.org/proteomics.yml.lock
+++ b/usegalaxy.org/proteomics.yml.lock
@@ -199,6 +199,6 @@ tools:
 - name: reactome_cli
   owner: paul_wolfe
   revisions:
-  - 50dabf20fe88
+  - d965cc86f7f5
   tool_panel_section_id: proteomics
   tool_panel_section_label: Proteomics

--- a/usegalaxy.org/proteomics.yml.lock
+++ b/usegalaxy.org/proteomics.yml.lock
@@ -196,3 +196,9 @@ tools:
   - d6dcd3173bdf
   tool_panel_section_id: proteomics
   tool_panel_section_label: Proteomics
+- name: reactome_cli
+  owner: paul_wolfe
+  revisions:
+  - 50dabf20fe88
+  tool_panel_section_id: proteomics
+  tool_panel_section_label: Proteomics


### PR DESCRIPTION
We would like to add the reactome pathway analysis official CLI tool and Galaxy integration to usegalaxy.org. This tool includes all pathway analysis available via our web APIs and integration with the ReactomeGSA R tooling.

TODO: Please replace this header with a description of your pull request.

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
