### PR TITLE
Install kMetaShot

### DIFF
--- a/usegalaxy.org/metagenomic_analysis.yml
+++ b/usegalaxy.org/metagenomic_analysis.yml
@@ -218,3 +218,5 @@ tools:
   owner: rplanel
 - name: iphop_predict
   owner: ufz
+- name: kmetashot
+  owner: lmansi

--- a/usegalaxy.org/metagenomic_analysis.yml.lock
+++ b/usegalaxy.org/metagenomic_analysis.yml.lock
@@ -911,3 +911,9 @@ tools:
   - d357350b6da0
   tool_panel_section_id: metagenomic_analysis
   tool_panel_section_label: Metagenomic Analysis
+- name: kmetashot
+  owner: lmansi
+  revisions:
+  - 50024f0c2536
+  tool_panel_section_id: metagenomic_analysis
+  tool_panel_section_label: Metagenomic Analysis


### PR DESCRIPTION
kMetaShot is a tool for taxonomic classification of Metagenome Assembled Genomes. Please, take into the account to install kMetaShot on galaxy.eu.

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
