### PR TITLE
Add MetaSBT suite

### DIFF
--- a/test.galaxyproject.org/metagenomic_analysis.yml
+++ b/test.galaxyproject.org/metagenomic_analysis.yml
@@ -55,3 +55,7 @@ tools:
   owner: iuc
 - name: data_manager_dada2
   owner: iuc
+- name: metasbt_index
+  owner: iuc
+- name: metasbt_profile
+  owner: iuc

--- a/test.galaxyproject.org/metagenomic_analysis.yml.lock
+++ b/test.galaxyproject.org/metagenomic_analysis.yml.lock
@@ -162,3 +162,15 @@ tools:
   - bf7b2c14cabc
   tool_panel_section_id: metagenomic_analysis
   tool_panel_section_label: Metagenomic Analysis
+- name: metasbt_index
+  owner: iuc
+  revisions:
+  - dff5f0dd17eb
+  tool_panel_section_id: metagenomic_analysis
+  tool_panel_section_label: Metagenomic Analysis
+- name: metasbt_profile
+  owner: iuc
+  revisions:
+  - 14515a211bd9
+  tool_panel_section_id: metagenomic_analysis
+  tool_panel_section_label: Metagenomic Analysis

--- a/usegalaxy.org/metagenomic_analysis.yml
+++ b/usegalaxy.org/metagenomic_analysis.yml
@@ -218,3 +218,7 @@ tools:
   owner: rplanel
 - name: iphop_predict
   owner: ufz
+- name: metasbt_index
+  owner: iuc
+- name: metasbt_profile
+  owner: iuc

--- a/usegalaxy.org/metagenomic_analysis.yml.lock
+++ b/usegalaxy.org/metagenomic_analysis.yml.lock
@@ -911,3 +911,15 @@ tools:
   - d357350b6da0
   tool_panel_section_id: metagenomic_analysis
   tool_panel_section_label: Metagenomic Analysis
+- name: metasbt_index
+  owner: iuc
+  revisions:
+  - dff5f0dd17eb
+  tool_panel_section_id: metagenomic_analysis
+  tool_panel_section_label: Metagenomic Analysis
+- name: metasbt_profile
+  owner: iuc
+  revisions:
+  - 14515a211bd9
+  tool_panel_section_id: metagenomic_analysis
+  tool_panel_section_label: Metagenomic Analysis


### PR DESCRIPTION
Add MetaSBT suite (`metasbt_index` and `metasbt_profile`) to the Metagenomic Analysis section.
https://github.com/galaxyproject/tools-iuc/pull/7141

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
