### PR TITLE
 Add RGI (card/rgi) to usegalaxy.org

### DIFF
--- a/usegalaxy.org/metagenomic_analysis.yml
+++ b/usegalaxy.org/metagenomic_analysis.yml
@@ -234,3 +234,5 @@ tools:
   owner: iuc
 - name: name2taxid
   owner: iuc
+- name: rgi
+  owner: card

--- a/usegalaxy.org/metagenomic_analysis.yml.lock
+++ b/usegalaxy.org/metagenomic_analysis.yml.lock
@@ -982,3 +982,9 @@ tools:
   - 954448bad930
   tool_panel_section_id: metagenomic_analysis
   tool_panel_section_label: Metagenomic Analysis
+- name: rgi
+  owner: card
+  revisions:
+  - 84bd24ac33fd
+  tool_panel_section_id: metagenomic_analysis
+  tool_panel_section_label: Metagenomic Analysis


### PR DESCRIPTION
RGI is widely used for antimicrobial resistance (AMR) gene detection from sequencing data and has been requested by BioDigs to be added. 

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
