### PR TITLE
Change reactome_cli revision in proteomics.yml.lock

### DIFF
--- a/usegalaxy.org/proteomics.yml.lock
+++ b/usegalaxy.org/proteomics.yml.lock
@@ -200,7 +200,6 @@ tools:
 - name: reactome_cli
   owner: paul_wolfe
   revisions:
-  - 6dba39f7916f
-  - d965cc86f7f5
+  - 6cdacc26e8f4
   tool_panel_section_id: proteomics
   tool_panel_section_label: Proteomics


### PR DESCRIPTION
Updated the reactome_cli revision in the lock file.

This is changing to a new version of the reactome-cli. With this new version comes a couple of minor help section fixes to point to our example data files.

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
