### PR TITLE
Add KSTAR tool to test galaxy server

### DIFF
--- a/test.galaxyproject.org/kinase_activity_inference.yml
+++ b/test.galaxyproject.org/kinase_activity_inference.yml
@@ -1,0 +1,4 @@
+tool_panel_section_label: Kinase Activity Inference
+tools:
+- name: kstar_calculate
+  owner: naegle_lab

--- a/test.galaxyproject.org/kinase_activity_inference.yml.lock
+++ b/test.galaxyproject.org/kinase_activity_inference.yml.lock
@@ -1,0 +1,11 @@
+install_repository_dependencies: false
+install_resolver_dependencies: false
+install_tool_dependencies: false
+tool_panel_section_label: Kinase Activity Inference
+tools:
+- name: kstar_calculate
+  owner: naegle_lab
+  revisions:
+  - 4ec757e2e5b7
+  tool_panel_section_id: kinase_activity_inference
+  tool_panel_section_label: Kinase Activity Inference


### PR DESCRIPTION
I have created a tool that runs the KSTAR algorithm (predicts kinase activity from phosphoproteomic data), which uses a dockerized version of the KSTAR algorithm. I would like to publish it to the test galaxy server for testing by my team. I created a new section called Kinase Activity Inference for this tool, as I did not see another appropriate .yml file that made sense (although a Proteomics section like one on the main server would work).

## Installation sequence for `tool-installers`
- [x] Test using `@galaxybot test this`
- [x] Inspect CI output for expected changes
- [x] Deploy using `@galaxybot deploy this` if test install was successful
- [x] Merge this PR
