### PR TITLE
Update Diamond to 2.1.22, restrict to metagenomic_analysis

### DIFF
--- a/usegalaxy.org/metagenomic_analysis.yml.lock
+++ b/usegalaxy.org/metagenomic_analysis.yml.lock
@@ -28,6 +28,7 @@ tools:
   - 64be1ac21109
   - 8b8a3f793f0f
   - 9553180705b7
+  - a02aa0dfb850
   - e8ac2b53f262
   tool_panel_section_id: metagenomic_analysis
   tool_panel_section_label: Metagenomic Analysis

--- a/usegalaxy.org/rna_seq.yml
+++ b/usegalaxy.org/rna_seq.yml
@@ -14,8 +14,6 @@ tools:
   owner: iuc
 - name: salmon
   owner: bgruening
-- name: diamond
-  owner: bgruening
 - name: kallisto_quant
   owner: iuc
 - name: kallisto_pseudo

--- a/usegalaxy.org/rna_seq.yml.lock
+++ b/usegalaxy.org/rna_seq.yml.lock
@@ -95,21 +95,6 @@ tools:
   - f4d5237a84f6
   tool_panel_section_id: rna_seq
   tool_panel_section_label: RNA-seq
-- name: diamond
-  owner: bgruening
-  revisions:
-  - 0cdcf7e99b62
-  - 1e3323a44643
-  - 20d92dc4c6cb
-  - 54f751e413f4
-  - 60f307965815
-  - 62c9df8382c2
-  - 64be1ac21109
-  - 8b8a3f793f0f
-  - 9553180705b7
-  - e8ac2b53f262
-  tool_panel_section_id: rna_seq
-  tool_panel_section_label: RNA-seq
 - name: kallisto_quant
   owner: iuc
   revisions:


### PR DESCRIPTION
## Summary
- Add Diamond revision `a02aa0dfb850` (2.1.22+galaxy0) to metagenomic_analysis section
- Remove Diamond from rna_seq section (both `.yml` and `.yml.lock`)

## Test plan
- [ ] Verify `make TOOLSET=usegalaxy.org lint` passes
- [ ] Confirm Diamond 2.1.22 installs correctly in metagenomic_analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)