### PR TITLE
Bump revisions of physicell IT on the test server

### DIFF
--- a/test.galaxyproject.org/interactive_tools.yml.lock
+++ b/test.galaxyproject.org/interactive_tools.yml.lock
@@ -14,12 +14,14 @@ tools:
   revisions:
   - b670740cf3f7
   - dd051f391a2c
+  - 16d22d97a2b3
   tool_panel_section_id: interactive_tools
   tool_panel_section_label: Interactive Tools
 - name: physicell_studio
   owner: rheiland
   revisions:
   - 4bf243935e55
+  - e49f9612b0bf
   tool_panel_section_id: interactive_tools
   tool_panel_section_label: Interactive Tools
   tool_shed_url: testtoolshed.g2.bx.psu.edu


### PR DESCRIPTION
Update interactive_tools.yml.lock to include new tool revisions. Added revision 16d22d97a2b3 to the first interactive tool entry and revision e49f9612b0bf to the physicell_studio entry to track recent updates.

Discussed with Nate a while ago; decided to keep both entries (main toolshed and test toolshed) for PhysiCell IT on the test server.

## Installation sequence for `tool-installers`
- [x] Test using `@galaxybot test this`
- [x] Inspect CI output for expected changes
- [x] Deploy using `@galaxybot deploy this` if test install was successful
- [x] Merge this PR
