### PR TITLE
Add xlsx2tsv to usegalaxy.org

### DIFF
--- a/usegalaxy.org/convert_formats.yml
+++ b/usegalaxy.org/convert_formats.yml
@@ -20,6 +20,8 @@ tools:
   owner: devteam
 - name: fastq_to_tabular
   owner: devteam
+- name: xlsx2tsv
+  owner: ufz
 - name: bax2bam
   owner: iuc
 - name: crossmap_bam

--- a/usegalaxy.org/convert_formats.yml.lock
+++ b/usegalaxy.org/convert_formats.yml.lock
@@ -88,6 +88,12 @@ tools:
   - ccf4e1d1fcbe
   tool_panel_section_id: convert_formats
   tool_panel_section_label: Convert Formats
+- name: xlsx2tsv
+  owner: ufz
+  revisions:
+  - 27bc52511ebe
+  tool_panel_section_id: convert_formats
+  tool_panel_section_label: Convert Formats
 - name: bax2bam
   owner: iuc
   revisions:


### PR DESCRIPTION
## What changed

Adds the Main Tool Shed repository `ufz/xlsx2tsv` to the `usegalaxy.org` Convert Formats tool panel section and locks it to revision `27bc52511ebe`.

## Why

`xlsx2tsv` converts Excel workbooks into TSV output, so the existing Convert Formats section is the most appropriate placement.

## Validation

- `python3 scripts/fix_lockfile.py usegalaxy.org/convert_formats.yml`
- `python3 scripts/update_tool.py --without usegalaxy.org/convert_formats.yml`
- `uv run --with pykwalify pykwalify -d usegalaxy.org/convert_formats.yml -s .schema.yml`
- `git diff --check`

Note: `ufz` is not one of the trusted owners called out in the README, so this may need the usual independent tool review before deployment.
