### PR TITLE
Add xlsx2tsv convert tool

### DIFF
--- a/usegalaxy.org/convert_formats.yml
+++ b/usegalaxy.org/convert_formats.yml
@@ -20,6 +20,8 @@ tools:
   owner: devteam
 - name: fastq_to_tabular
   owner: devteam
+- name: xlsx2tsv
+  owner: ufz
 - name: bax2bam
   owner: iuc
 - name: crossmap_bam

--- a/usegalaxy.org/convert_formats.yml.lock
+++ b/usegalaxy.org/convert_formats.yml.lock
@@ -88,6 +88,12 @@ tools:
   - ccf4e1d1fcbe
   tool_panel_section_id: convert_formats
   tool_panel_section_label: Convert Formats
+- name: xlsx2tsv
+  owner: ufz
+  revisions:
+  - 27bc52511ebe
+  tool_panel_section_id: convert_formats
+  tool_panel_section_label: Convert Formats
 - name: bax2bam
   owner: iuc
   revisions:


### PR DESCRIPTION
Add a new convert_formats.yml entry for the xlsx2tsv tool with owner 'ufz' so the XLSX-to-TSV conversion tool is registered in the Convert Formats section. This tool has been installed on the EU server: https://usegalaxy.eu/root?tool_id=xlsx2tsv


## Installation sequence for `tool-installers`
- [x] passed the automated run galaxybot test
- [x] Inspect CI output for expected changes
- [x] Deploy using `@galaxybot deploy this` if test install was successful
- [x] Merge this PR
