### PR TITLE
Add unzip to usegalaxy.org

### DIFF
--- a/usegalaxy.org/convert_formats.yml
+++ b/usegalaxy.org/convert_formats.yml
@@ -70,5 +70,7 @@ tools:
   owner: iuc
 - name: rds_to_tabular
   owner: goeckslab
+- name: unzip
+  owner: imgteam
 - name: ucsc_nettoaxt
   owner: iuc

--- a/usegalaxy.org/convert_formats.yml.lock
+++ b/usegalaxy.org/convert_formats.yml.lock
@@ -326,6 +326,12 @@ tools:
   - 1020a80225b1
   tool_panel_section_id: convert_formats
   tool_panel_section_label: Convert Formats
+- name: unzip
+  owner: imgteam
+  revisions:
+  - 6a7e010c05db
+  tool_panel_section_id: convert_formats
+  tool_panel_section_label: Convert Formats
 - name: ucsc_nettoaxt
   owner: iuc
   revisions:


### PR DESCRIPTION
Adds `imgteam/unzip` to the Convert Formats section on usegalaxy.org.

This tool extracts ZIP/TAR archives into datasets or collections and is already installed on usegalaxy.eu.

## Installation sequence for `tool-installers`
- [x] automated test run
- [x] Inspect CI output for expected changes
- [x] Deploy using `@galaxybot deploy this` if test install was successful
- [x] Merge this PR
