### PR TITLE
Updating to newest version of RGI main and BWT

### DIFF
--- a/usegalaxy.org/metagenomic_analysis.yml.lock
+++ b/usegalaxy.org/metagenomic_analysis.yml.lock
@@ -1092,13 +1092,11 @@ tools:
   owner: tcollins
   revisions:
   - bff51051d70f
-  - c2ba21bd8f34
   tool_panel_section_id: metagenomic_analysis
   tool_panel_section_label: Metagenomic Analysis
 - name: rgi_main
   owner: tcollins
   revisions:
-  - 15d244ecf848
   - 6c8ccbb19438
   tool_panel_section_id: metagenomic_analysis
   tool_panel_section_label: Metagenomic Analysis

--- a/usegalaxy.org/metagenomic_analysis.yml.lock
+++ b/usegalaxy.org/metagenomic_analysis.yml.lock
@@ -1091,8 +1091,8 @@ tools:
 - name: rgi_bwt
   owner: tcollins
   revisions:
-  - c2ba21bd8f34
   - bff51051d70f
+  - c2ba21bd8f34
   tool_panel_section_id: metagenomic_analysis
   tool_panel_section_label: Metagenomic Analysis
 - name: rgi_main

--- a/usegalaxy.org/metagenomic_analysis.yml.lock
+++ b/usegalaxy.org/metagenomic_analysis.yml.lock
@@ -1092,11 +1092,13 @@ tools:
   owner: tcollins
   revisions:
   - c2ba21bd8f34
+  - bff51051d70f
   tool_panel_section_id: metagenomic_analysis
   tool_panel_section_label: Metagenomic Analysis
 - name: rgi_main
   owner: tcollins
   revisions:
   - 15d244ecf848
+  - 6c8ccbb19438
   tool_panel_section_id: metagenomic_analysis
   tool_panel_section_label: Metagenomic Analysis


### PR DESCRIPTION
When I removed the data managers last time I forgot to regenerate the .lock with newest version of the RGI suite. This is just updating them both to the newest version to include the new datatable with 7 columns instead of 6. 

## Installation sequence for `tool-installers`
- [ ] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
