### PR TITLE
Update Physicell Studio testtoolshed revision on test server

### DIFF
--- a/test.galaxyproject.org/interactive_tools.yml.lock
+++ b/test.galaxyproject.org/interactive_tools.yml.lock
@@ -26,6 +26,7 @@ tools:
   - b66cf906193c
   - d98d958e3937
   - ea8ceaf68518
+  - 500882207f95
   tool_panel_section_id: interactive_tools
   tool_panel_section_label: Interactive Tools
   tool_shed_url: testtoolshed.g2.bx.psu.edu


### PR DESCRIPTION
Updates the Test Tool Shed `rheiland/physicell_studio` lockfile entry for `test.galaxyproject.org` to include the latest ordered installable revision requested by Randy:

- Test Tool Shed repository: https://testtoolshed.g2.bx.psu.edu/repositories/d02c81bcefcd82cc
- New revision: `500882207f95`
- Previous latest installed Test Tool Shed revision: `ea8ceaf68518`

## Installation sequence for `tool-installers`
- [x] Test using `@galaxybot test this`
- [x] Inspect CI output for expected changes
- [x] Deploy using `@galaxybot deploy this` if test install was successful
- [x] Merge this PR

