### PR TITLE
Update Physicell Studio usegalaxy revision

### DIFF
--- a/usegalaxy.org/interactive_tools.yml.lock
+++ b/usegalaxy.org/interactive_tools.yml.lock
@@ -34,6 +34,7 @@ tools:
   - 51fce75ceb4b
   - 94cb50e04648
   - b670740cf3f7
+  - d1c1889284f4
   - dd051f391a2c
   - debe29745559
   - f91d52f117fe


### PR DESCRIPTION
Updates the Main Tool Shed `rheiland/physicell_studio` lockfile entry for `usegalaxy.org` to include the latest ordered installable revision:

- New revision: `d1c1889284f4`
- Previous latest installed Main Tool Shed revision: `51fce75ceb4b`
- Tool version: `0.12`

## Installation sequence for `tool-installers`
- [x] Test using `@galaxybot test this`
- [x] Inspect CI output for expected changes
- [x] Deploy using `@galaxybot deploy this` if test install was successful
- [x] Merge this PR

