### PR TITLE
Install metagenomics data managers on test.galaxyproject.org

### DIFF
--- a/test.galaxyproject.org/data_managers.yml
+++ b/test.galaxyproject.org/data_managers.yml
@@ -52,3 +52,9 @@ tools:
   owner: iuc
 - name: custom_pro_db_annotation_data_manager
   owner: galaxyp
+- name: data_manager_metaphlan_database_downloader
+  owner: iuc
+- name: data_manager_samestr
+  owner: iuc
+- name: data_manager_motus
+  owner: bgruening

--- a/test.galaxyproject.org/data_managers.yml.lock
+++ b/test.galaxyproject.org/data_managers.yml.lock
@@ -1,4 +1,4 @@
-install_repository_dependencies: true
+install_repository_dependencies: false
 install_resolver_dependencies: false
 install_tool_dependencies: false
 tool_panel_section_label: Data Managers
@@ -160,5 +160,23 @@ tools:
   owner: galaxyp
   revisions:
   - 9ee512decde8
+  tool_panel_section_id: data_managers
+  tool_panel_section_label: Data Managers
+- name: data_manager_metaphlan_database_downloader
+  owner: iuc
+  revisions:
+  - 2c22b676ec46
+  tool_panel_section_id: data_managers
+  tool_panel_section_label: Data Managers
+- name: data_manager_samestr
+  owner: iuc
+  revisions:
+  - e8873a70f416
+  tool_panel_section_id: data_managers
+  tool_panel_section_label: Data Managers
+- name: data_manager_motus
+  owner: bgruening
+  revisions:
+  - c153e8dd94ad
   tool_panel_section_id: data_managers
   tool_panel_section_label: Data Managers


### PR DESCRIPTION
## What

Installs three metagenomics **data managers** on `test.galaxyproject.org`:

| Data manager | Owner | Populates data table |
|---|---|---|
| `data_manager_metaphlan_database_downloader` | iuc | `metaphlan_database_versioned` |
| `data_manager_samestr` | iuc | `samestr_db` (built from an installed MetaPhlAn DB) |
| `data_manager_motus` | bgruening | `motus_db_versioned` |

## Why

These data managers back the IDC reference-data **workflow-bundle** pipeline: contributors request a reference-data version via a YAML PR, and a gxformat2 data-manager-bundle workflow is run on test.galaxyproject.org (via planemo) to produce importable bundles for CVMFS. SameStr's marker DB is built by chaining on a MetaPhlAn database, which is why all three are needed together.

## Notes

- Only `test.galaxyproject.org/data_managers.yml` (+ generated `.lock`) are touched.
- Revisions were pinned with `make TOOLSET=test.galaxyproject.org fix`: metaphlan `2c22b676ec46`, samestr `e8873a70f416`, motus `c153e8dd94ad`.
- The lockfile's global `install_repository_dependencies` flips `true → false`; this is what the current `scripts/fix_lockfile.py` (and thus `make lint`) regenerates, not a deliberate policy change.