### PR TITLE
Update data_manager_samestr to 1.2025.111+galaxy2 on test.galaxyproject.org

### DIFF
--- a/test.galaxyproject.org/data_managers.yml.lock
+++ b/test.galaxyproject.org/data_managers.yml.lock
@@ -172,6 +172,7 @@ tools:
   owner: iuc
   revisions:
   - e8873a70f416
+  - 405af1001762
   tool_panel_section_id: data_managers
   tool_panel_section_label: Data Managers
 - name: data_manager_motus


### PR DESCRIPTION
Pins the new toolshed revision `405af1001762` (`1.2025.111+galaxy2`) for `iuc/data_manager_samestr` on test.galaxyproject.org.

This is the fix merged in [galaxyproject/tools-iuc#8172](https://github.com/galaxyproject/tools-iuc/commit/4d59f417571bc4c3a2ee1c81353ed3e7c43e4a89): the samestr DB builder now reconstructs the MetaPhlAn markers from the bowtie2 index (`bowtie2-inspect`) when the raw FASTA is absent, and declares `bowtie2` as a requirement. Real MetaPhlAn databases only ship the `.pkl` + `.bt2l` index (the installer deletes the marker FASTA), so the previous `galaxy1` revision only ever passed against a hand-made `.fna` test fixture.

Needed so the IDC reference-data pipeline can build the samestr DB workflow bundle against a real MetaPhlAn database on test.galaxyproject.org.

Appended the new revision (kept `e8873a70f416`), matching `scripts/update_tool.py`.