### PR TITLE
Update data_manager_motus to 3.1.0+galaxy1 on test.galaxyproject.org

### DIFF
--- a/test.galaxyproject.org/data_managers.yml.lock
+++ b/test.galaxyproject.org/data_managers.yml.lock
@@ -179,5 +179,6 @@ tools:
   owner: bgruening
   revisions:
   - c153e8dd94ad
+  - 603939ba21ec
   tool_panel_section_id: data_managers
   tool_panel_section_label: Data Managers


### PR DESCRIPTION
Pins the new toolshed revision `603939ba21ec` (`motus_db_fetcher/3.1.0+galaxy1`), from the just-merged update to `bgruening/galaxytools` `data_manager_motus_db_downloader`.

Needed so the reference-data workflow-bundle pipeline can install the fixed mOTUs DB fetcher on test.galaxyproject.org. Follows the same pattern as #1596 (samestr galaxy2).

Old revision `c153e8dd94ad` (galaxy0) is retained; only the new revision is appended.