### PR TITLE
Update Physicell Studio testtoolshed revision

### DIFF
--- a/test.galaxyproject.org/interactive_tools.yml.lock
+++ b/test.galaxyproject.org/interactive_tools.yml.lock
@@ -29,6 +29,7 @@ tools:
   - 500882207f95
   - 0d215c8381c4
   - e88709ce8e25
+  - d302ce0877f7
   tool_panel_section_id: interactive_tools
   tool_panel_section_label: Interactive Tools
   tool_shed_url: testtoolshed.g2.bx.psu.edu


### PR DESCRIPTION
Adds the latest Test Tool Shed revision of `rheiland/physicell_studio` to the Test interactive tools lockfile.

- Added revision: `d302ce0877f7`
- Tool: `interactive_tool_pcstudio`
- Tool version: `0.14.3`

## Installation sequence for `tool-installers`
- [x] Test using `@galaxybot test this`
- [x] Inspect CI output for expected changes
- [x] Deploy using `@galaxybot deploy this` if test install was successful
- [x] Merge this PR
