### PR TITLE
Update Physicell Studio main revision

### DIFF
--- a/usegalaxy.org/interactive_tools.yml.lock
+++ b/usegalaxy.org/interactive_tools.yml.lock
@@ -38,6 +38,7 @@ tools:
   - d1c1889284f4
   - dd051f391a2c
   - debe29745559
+  - e84a12b5ffed
   - f91d52f117fe
   tool_panel_section_id: interactive_tools
   tool_panel_section_label: Interactive Tools


### PR DESCRIPTION
Adds the latest Main Tool Shed revision of `rheiland/physicell_studio` to the usegalaxy.org interactive tools lockfile.

- Added revision: `e84a12b5ffed`
- Tool: `interactive_tool_pcstudio`
- Tool version: `0.14.3`

## Installation sequence for `tool-installers`
- [x] Test using `@galaxybot test this`
- [x] Inspect CI output for expected changes
- [x] Deploy using `@galaxybot deploy this` if test install was successful
- [x] Merge this PR