### PR TITLE
Add ClipKIT to usegalaxy.org

### DIFF
--- a/usegalaxy.org/annotation.yml
+++ b/usegalaxy.org/annotation.yml
@@ -84,6 +84,8 @@ tools:
   owner: iuc
 - name: bicodon_counts_from_fasta
   owner: iuc
+- name: clipkit
+  owner: iuc
 - name: codon_freq_from_bicodons
   owner: iuc
 - name: antismash

--- a/usegalaxy.org/annotation.yml.lock
+++ b/usegalaxy.org/annotation.yml.lock
@@ -351,6 +351,12 @@ tools:
   - e13169dca7c8
   tool_panel_section_id: annotation
   tool_panel_section_label: Annotation
+- name: clipkit
+  owner: iuc
+  revisions:
+  - 28f191865f6b
+  tool_panel_section_id: annotation
+  tool_panel_section_label: Annotation
 - name: codon_freq_from_bicodons
   owner: iuc
   revisions:


### PR DESCRIPTION
## Summary

- add the IUC-maintained `clipkit` Tool Shed repository to the `Annotation` section on usegalaxy.org
- lock its installable Main Tool Shed revision, `28f191865f6b`

## Motivation

ClipKIT trims multiple sequence alignments while retaining phylogenetically informative sites. Its Galaxy wrapper was reviewed and merged in galaxyproject/tools-iuc#8183, deployed successfully to the Main Tool Shed, and has also been selected for installation on Galaxy EU in usegalaxy-eu/usegalaxy-eu-tools#1088.

This PR requests the corresponding installation on Galaxy USA, following the guidance in usegalaxy-eu/usegalaxy-eu-tools#868.

## Validation

- `make TOOLSET=usegalaxy.org fix`
- `make TOOLSET=usegalaxy.org lint`
- confirmed `iuc/clipkit` revision `28f191865f6b` is installable from the Main Tool Shed through Bioblend
- confirmed the generated diff is limited to `usegalaxy.org/annotation.yml` and `usegalaxy.org/annotation.yml.lock`

## Deployment notes

- the repository is maintained by the IUC
- the wrapper uses `${GALAXY_SLOTS:-1}` for its thread count
- no custom memory requirement is known
