### PR TITLE
Add psauron to usegalaxy.org

### DIFF
--- a/usegalaxy.org/annotation.yml
+++ b/usegalaxy.org/annotation.yml
@@ -198,3 +198,5 @@ tools:
   owner: iuc
 - name: hmmer_phmmer
   owner: iuc
+- name: psauron
+  owner: iuc

--- a/usegalaxy.org/annotation.yml.lock
+++ b/usegalaxy.org/annotation.yml.lock
@@ -776,3 +776,9 @@ tools:
   - 37bcc9fb0bb1
   tool_panel_section_id: annotation
   tool_panel_section_label: Annotation
+- name: psauron
+  owner: iuc
+  revisions:
+  - 5fc148ebafbc
+  tool_panel_section_id: annotation
+  tool_panel_section_label: Annotation


### PR DESCRIPTION
Adds the [PSAURON](https://github.com/salzberg-lab/PSAURON) tool (`iuc/psauron`, Main Tool Shed) to the Annotation section on usegalaxy.org.

PSAURON is a machine learning model for rapid assessment of protein-coding gene annotation. It is already available on usegalaxy.eu.

Requested via community (Slack): inclusion on usegalaxy.org.

- IUC-maintained, so no independent review required per repo policy.
- Lock revision: `5fc148ebafbc`.