### PR TITLE
Update GLEAM tool revisions on usegalaxy.org

### DIFF
--- a/usegalaxy.org/machine_learning.yml.lock
+++ b/usegalaxy.org/machine_learning.yml.lock
@@ -20,6 +20,7 @@ tools:
   - a5404f55ee6a
   - a92f200d296e
   - b905deb2f1b4
+  - baa13bb4cdcc
   - dbf05afb8e6c
   - de753cf07008
   - ed2fefc8d892
@@ -39,6 +40,7 @@ tools:
   - bbf30253c99f
   - c460abae83eb
   - c5150cceab47
+  - c99a4e91b900
   - ccbcc012d78d
   - d17e3a1b8659
   - d5c582cf74bc
@@ -60,6 +62,7 @@ tools:
   - 49f73a3c12f3
   - 4bd75b45a7a1
   - 575cb355247c
+  - 6708cb8547bc
   - 8a1c986bb0b0
   - ba45bc057d70
   - bf0df21a1ea3


### PR DESCRIPTION
This updates `usegalaxy.org/machine_learning.yml.lock` with the latest
installable changesets for:

- `goeckslab/multimodal_learner@baa13bb4cdcc` (tool version `0.1.9`)
- `goeckslab/image_learner@c99a4e91b900` (tool version `0.1.6`)
- `goeckslab/tabular_learner@6708cb8547bc` (tool version `0.1.5`)

## Installation sequence for `tool-installers`
- [x] Test using `@galaxybot test this`
- [x] Inspect CI output for expected changes
- [x] Deploy using `@galaxybot deploy this` if test install was successful
- [x] Merge this PR
