### PR TITLE
Harden Tool Shed update automation

### DIFF
--- a/.github/workflows/test-update-tool.yml
+++ b/.github/workflows/test-update-tool.yml
@@ -1,0 +1,22 @@
+name: Test Tool Shed updater
+
+on:
+  pull_request:
+    branches: ["master"]
+    paths:
+      - "scripts/update_tool.py"
+      - "tests/**"
+      - "requirements.txt"
+      - ".github/workflows/test-update-tool.yml"
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: python -m unittest discover -s tests -v

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ fix: ## Fix all lockfiles and add any missing revisions
 	@# Generates the lockfile or updates it if it is missing tools
 	find ./$(TOOLSET) -name '*.yml' ! -path .//.schema.yml | grep '^\./[^/]*/' | xargs -n 1 -P 8 python scripts/fix_lockfile.py
 	@# --without says only add those hashes for those missing hashes (zB new tools)
-	find ./$(TOOLSET) -name '*.yml' ! -path .//.schema.yml | grep '^\./[^/]*/' | xargs -n 1 -P 8 python scripts/update_tool.py --without
+	find ./$(TOOLSET) -name '*.yml' ! -path .//.schema.yml | grep '^\./[^/]*/' | xargs -P 1 python scripts/update_tool.py --without
 
 fix-no-deps:
 	find ./$(TOOLSET) -name '*.yml' ! -path .//.schema.yml  | grep '^\./[^/]*/' | xargs -n 1 -P 8 python scripts/fix_lockfile.py --no-install-repository-dependencies --no-install-resolver-dependencies
-	find ./$(TOOLSET) -name '*.yml' ! -path .//.schema.yml | grep '^\./[^/]*/' | xargs -n 1 -P 8 python scripts/update_tool.py --without
+	find ./$(TOOLSET) -name '*.yml' ! -path .//.schema.yml | grep '^\./[^/]*/' | xargs -P 1 python scripts/update_tool.py --without
 
 #install:
 	#@echo "Installing any updated versions of $<"
@@ -30,9 +30,9 @@ fix-no-deps:
 
 update-trusted: ## Run the update script for a subset of repos
 	@# Missing --without, so this updates all tools in the file.
-	find ./$(TOOLSET) -name '*.yml' ! -path .//.schema.yml | grep '^\./[^/]*/' | xargs -n 1 -P 8 python scripts/update_tool.py --owner $(OWNER)
+	find ./$(TOOLSET) -name '*.yml' ! -path .//.schema.yml | grep '^\./[^/]*/' | xargs -P 1 python scripts/update_tool.py --owner $(OWNER)
 
 update-all: ## Run the update script for all repos
-	find ./$(TOOLSET) -name '*.yml' ! -path .//.schema.yml | grep '^\./[^/]*/' | xargs -n 1 -P 8 python scripts/update_tool.py
+	find ./$(TOOLSET) -name '*.yml' ! -path .//.schema.yml | grep '^\./[^/]*/' | xargs -P 1 python scripts/update_tool.py
 
 .PHONY: lint update-trusted update-all help fix

--- a/scripts/update_tool.py
+++ b/scripts/update_tool.py
@@ -79,7 +79,7 @@ def update_file(fn, owner=None, name=None, without=False, stats=None, failures=N
                 elif status >= 500:
                     stats['server_errors'] += 1
                 if status == 404:
-                    failure = '{owner}/{name}: {error}'.format(error=error, **tool)
+                    failure = '{owner}/{name}: HTTP {status}'.format(status=status, **tool)
                     failures.append(failure)
                     logging.error('Repository update failed; continuing scan: %s', failure)
                     break

--- a/scripts/update_tool.py
+++ b/scripts/update_tool.py
@@ -30,42 +30,9 @@ tool_sheds = ToolSheds()
 last_request_at = 0
 
 
-def get_revisions(tool, stats):
+def update_file(fn, owner=None, name=None, without=False, stats=None):
     global last_request_at
 
-    tool_shed = tool_sheds[tool.get('tool_shed_url', DEFAULT_TOOL_SHED_URL)]
-    for attempt in range(MAX_ATTEMPTS):
-        delay = REQUEST_INTERVAL - (time.monotonic() - last_request_at)
-        if delay > 0:
-            time.sleep(delay)
-        last_request_at = time.monotonic()
-        stats['requests'] += 1
-
-        try:
-            return tool_shed.repositories.get_ordered_installable_revisions(tool['name'], tool['owner'])
-        except (ConnectionError, requests.RequestException) as error:
-            status = getattr(error, 'status_code', None)
-            if status == 429:
-                stats['rate_limits'] += 1
-            elif status is None:
-                stats['network_errors'] += 1
-            elif status >= 500:
-                stats['server_errors'] += 1
-            if status not in TRANSIENT_STATUS_CODES or attempt == MAX_ATTEMPTS - 1:
-                raise
-            stats['retries'] += 1
-            retry_delay = 2 ** attempt
-            logging.warning(
-                'Transient Tool Shed error for %s/%s (%s); retrying in %ss',
-                tool['owner'],
-                tool['name'],
-                error,
-                retry_delay,
-            )
-            time.sleep(retry_delay)
-
-
-def update_file(fn, owner=None, name=None, without=False, stats=None):
     if stats is None:
         stats = defaultdict(int)
 
@@ -86,12 +53,39 @@ def update_file(fn, owner=None, name=None, without=False, stats=None):
         tool_shed_url = tool.get('tool_shed_url', DEFAULT_TOOL_SHED_URL)
         if tool_shed_url != DEFAULT_TOOL_SHED_URL:
             logging.warning('Non-default Tool Shed URL for %s/%s: %s', tool['owner'], tool['name'], tool_shed_url)
+        tool_shed = tool_sheds[tool_shed_url]
 
         logging.info("Fetching updates for {owner}/{name}".format(**tool))
-        try:
-            revisions = get_revisions(tool, stats)
-        except Exception as error:
-            raise RuntimeError('{owner}/{name}: {error}'.format(error=error, **tool)) from error
+        for attempt in range(MAX_ATTEMPTS):
+            delay = REQUEST_INTERVAL - (time.monotonic() - last_request_at)
+            if delay > 0:
+                time.sleep(delay)
+            last_request_at = time.monotonic()
+            stats['requests'] += 1
+
+            try:
+                revisions = tool_shed.repositories.get_ordered_installable_revisions(tool['name'], tool['owner'])
+                break
+            except (ConnectionError, requests.RequestException) as error:
+                status = getattr(error, 'status_code', None)
+                if status == 429:
+                    stats['rate_limits'] += 1
+                elif status is None:
+                    stats['network_errors'] += 1
+                elif status >= 500:
+                    stats['server_errors'] += 1
+                if status not in TRANSIENT_STATUS_CODES or attempt == MAX_ATTEMPTS - 1:
+                    raise RuntimeError('{owner}/{name}: {error}'.format(error=error, **tool)) from error
+                stats['retries'] += 1
+                retry_delay = 2 ** attempt
+                logging.warning(
+                    'Transient Tool Shed error for %s/%s (%s); retrying in %ss',
+                    tool['owner'],
+                    tool['name'],
+                    error,
+                    retry_delay,
+                )
+                time.sleep(retry_delay)
 
         if not revisions:
             raise RuntimeError('Tool Shed returned no revisions for {owner}/{name}'.format(**tool))

--- a/scripts/update_tool.py
+++ b/scripts/update_tool.py
@@ -59,6 +59,7 @@ def update_file(fn, owner=None, name=None, without=False, stats=None, failures=N
         tool_shed = tool_sheds[tool_shed_url]
 
         logging.debug("Fetching updates for {owner}/{name}".format(**tool))
+        failed = False
         revisions = None
         for attempt in range(MAX_ATTEMPTS):
             delay = REQUEST_INTERVAL - (time.monotonic() - last_request_at)
@@ -82,6 +83,7 @@ def update_file(fn, owner=None, name=None, without=False, stats=None, failures=N
                     failure = '{owner}/{name}: HTTP {status}'.format(status=status, **tool)
                     failures.append(failure)
                     logging.error('Repository update failed; continuing scan: %s', failure)
+                    failed = True
                     break
                 if status not in TRANSIENT_STATUS_CODES or attempt == MAX_ATTEMPTS - 1:
                     raise RuntimeError('{owner}/{name}: {error}'.format(error=error, **tool)) from error
@@ -96,7 +98,7 @@ def update_file(fn, owner=None, name=None, without=False, stats=None, failures=N
                 )
                 time.sleep(retry_delay)
 
-        if revisions is None:
+        if failed:
             continue
         if not revisions:
             failure = 'Tool Shed returned no revisions for {owner}/{name}'.format(**tool)

--- a/scripts/update_tool.py
+++ b/scripts/update_tool.py
@@ -58,7 +58,7 @@ def update_file(fn, owner=None, name=None, without=False, stats=None, failures=N
             logging.warning('Non-default Tool Shed URL for %s/%s: %s', tool['owner'], tool['name'], tool_shed_url)
         tool_shed = tool_sheds[tool_shed_url]
 
-        logging.info("Fetching updates for {owner}/{name}".format(**tool))
+        logging.debug("Fetching updates for {owner}/{name}".format(**tool))
         revisions = None
         for attempt in range(MAX_ATTEMPTS):
             delay = REQUEST_INTERVAL - (time.monotonic() - last_request_at)

--- a/scripts/update_tool.py
+++ b/scripts/update_tool.py
@@ -19,8 +19,9 @@ class ToolSheds(defaultdict):
     default_factory = toolshed.ToolShedInstance
 
     def __missing__(self, key):
-        logging.debug('Creating new ToolShedInstance for URL: %s', key)
-        tool_shed = self.default_factory(url=key)
+        url = key if key.lower().startswith(('http://', 'https://')) else 'https://' + key
+        logging.debug('Creating new ToolShedInstance for URL: %s', url)
+        tool_shed = self.default_factory(url=url)
         tool_shed.timeout = 30
         self[key] = tool_shed
         return tool_shed
@@ -30,11 +31,13 @@ tool_sheds = ToolSheds()
 last_request_at = 0
 
 
-def update_file(fn, owner=None, name=None, without=False, stats=None):
+def update_file(fn, owner=None, name=None, without=False, stats=None, failures=None):
     global last_request_at
 
     if stats is None:
         stats = defaultdict(int)
+    if failures is None:
+        failures = []
 
     with open(fn + '.lock', 'r') as handle:
         locked = yaml.safe_load(handle)
@@ -56,6 +59,7 @@ def update_file(fn, owner=None, name=None, without=False, stats=None):
         tool_shed = tool_sheds[tool_shed_url]
 
         logging.info("Fetching updates for {owner}/{name}".format(**tool))
+        revisions = None
         for attempt in range(MAX_ATTEMPTS):
             delay = REQUEST_INTERVAL - (time.monotonic() - last_request_at)
             if delay > 0:
@@ -74,6 +78,11 @@ def update_file(fn, owner=None, name=None, without=False, stats=None):
                     stats['network_errors'] += 1
                 elif status >= 500:
                     stats['server_errors'] += 1
+                if status == 404:
+                    failure = '{owner}/{name}: {error}'.format(error=error, **tool)
+                    failures.append(failure)
+                    logging.error('Repository update failed; continuing scan: %s', failure)
+                    break
                 if status not in TRANSIENT_STATUS_CODES or attempt == MAX_ATTEMPTS - 1:
                     raise RuntimeError('{owner}/{name}: {error}'.format(error=error, **tool)) from error
                 stats['retries'] += 1
@@ -87,8 +96,13 @@ def update_file(fn, owner=None, name=None, without=False, stats=None):
                 )
                 time.sleep(retry_delay)
 
+        if revisions is None:
+            continue
         if not revisions:
-            raise RuntimeError('Tool Shed returned no revisions for {owner}/{name}'.format(**tool))
+            failure = 'Tool Shed returned no revisions for {owner}/{name}'.format(**tool)
+            failures.append(failure)
+            logging.error('%s; continuing scan', failure)
+            continue
         stats['repositories'] += 1
         latest_revision = str(revisions[-1])
         if latest_revision in tool.get('revisions', []):
@@ -108,11 +122,11 @@ def update_file(fn, owner=None, name=None, without=False, stats=None):
         stats['files_written'] += 1
 
 
-def write_summary(stats, files_scanned, started, error=None):
+def write_summary(stats, files_scanned, started, failures):
     summary = '\n'.join([
         '## Tool Shed update summary',
         '',
-        '**Status:** {}'.format('failed' if error else 'completed'),
+        '**Status:** {}'.format('failed' if failures else 'completed'),
         '',
         '- Lockfiles scanned: {}'.format(files_scanned),
         '- Repositories checked: {}'.format(stats['repositories']),
@@ -124,11 +138,13 @@ def write_summary(stats, files_scanned, started, error=None):
         '- HTTP 429 responses: {}'.format(stats['rate_limits']),
         '- HTTP 5xx responses: {}'.format(stats['server_errors']),
         '- Network errors: {}'.format(stats['network_errors']),
-        '- Unresolved failures: {}'.format(1 if error else 0),
+        '- Unresolved failures: {}'.format(len(failures)),
         '- Duration: {:.1f}s'.format(time.monotonic() - started),
     ])
-    if error:
-        summary += '\n\n- Failure: `{}`'.format(str(error).replace('`', "'"))
+    if failures:
+        summary += '\n\n' + '\n'.join(
+            '- Failure: `{}`'.format(failure.replace('`', "'")) for failure in failures
+        )
     logging.info('\n%s', summary)
 
     if os.environ.get('GITHUB_STEP_SUMMARY'):
@@ -146,21 +162,22 @@ def main(argv=None):
     args = parser.parse_args(argv)
     logging.basicConfig(level=getattr(logging, args.log.upper()))
     stats = defaultdict(int)
+    failures = []
     started = time.monotonic()
     files_scanned = 0
-    error = None
 
     try:
         for fn in args.fn:
             files_scanned += 1
-            update_file(fn, owner=args.owner, name=args.name, without=args.without, stats=stats)
+            update_file(fn, owner=args.owner, name=args.name, without=args.without, stats=stats, failures=failures)
     except Exception as error:
         logging.error('Tool update failed: %s', error)
-        write_summary(stats, files_scanned, started, error)
+        failures.append(str(error))
+        write_summary(stats, files_scanned, started, failures)
         return 1
 
-    write_summary(stats, files_scanned, started)
-    return 0
+    write_summary(stats, files_scanned, started, failures)
+    return 1 if failures else 0
 
 
 if __name__ == '__main__':

--- a/scripts/update_tool.py
+++ b/scripts/update_tool.py
@@ -1,11 +1,18 @@
-import yaml
 import argparse
 import logging
+import os
+import time
 from collections import defaultdict
 
+import requests
+import yaml
 from bioblend import toolshed
+from bioblend.galaxy.client import ConnectionError
 
 DEFAULT_TOOL_SHED_URL = 'https://toolshed.g2.bx.psu.edu'
+REQUEST_INTERVAL = 0.25
+MAX_ATTEMPTS = 6
+TRANSIENT_STATUS_CODES = {None, 429, 500, 502, 503, 504}
 
 
 class ToolSheds(defaultdict):
@@ -13,72 +20,154 @@ class ToolSheds(defaultdict):
 
     def __missing__(self, key):
         logging.debug('Creating new ToolShedInstance for URL: %s', key)
-        return self.default_factory(url=key)
+        tool_shed = self.default_factory(url=key)
+        tool_shed.timeout = 30
+        self[key] = tool_shed
+        return tool_shed
 
 
 tool_sheds = ToolSheds()
+last_request_at = 0
 
 
-def update_file(fn, owner=None, name=None, without=False):
+def get_revisions(tool, stats):
+    global last_request_at
+
+    tool_shed = tool_sheds[tool.get('tool_shed_url', DEFAULT_TOOL_SHED_URL)]
+    for attempt in range(MAX_ATTEMPTS):
+        delay = REQUEST_INTERVAL - (time.monotonic() - last_request_at)
+        if delay > 0:
+            time.sleep(delay)
+        last_request_at = time.monotonic()
+        stats['requests'] += 1
+
+        try:
+            return tool_shed.repositories.get_ordered_installable_revisions(tool['name'], tool['owner'])
+        except (ConnectionError, requests.RequestException) as error:
+            status = getattr(error, 'status_code', None)
+            if status == 429:
+                stats['rate_limits'] += 1
+            elif status is None:
+                stats['network_errors'] += 1
+            elif status >= 500:
+                stats['server_errors'] += 1
+            if status not in TRANSIENT_STATUS_CODES or attempt == MAX_ATTEMPTS - 1:
+                raise
+            stats['retries'] += 1
+            retry_delay = 2 ** attempt
+            logging.warning(
+                'Transient Tool Shed error for %s/%s (%s); retrying in %ss',
+                tool['owner'],
+                tool['name'],
+                error,
+                retry_delay,
+            )
+            time.sleep(retry_delay)
+
+
+def update_file(fn, owner=None, name=None, without=False, stats=None):
+    if stats is None:
+        stats = defaultdict(int)
+
     with open(fn + '.lock', 'r') as handle:
         locked = yaml.safe_load(handle)
 
-    # Update any locked tools.
+    changed = False
     for tool in locked['tools']:
-        # If without, then if it is lacking, we should exec.
         logging.debug("Examining {owner}/{name}".format(**tool))
 
-        if without:
-            if 'revisions' in tool and not len(tool.get('revisions', [])) == 0:
-                continue
-
+        if without and tool.get('revisions'):
+            continue
         if not without and owner and tool['owner'] not in owner:
             continue
-
         if not without and name and tool['name'] != name:
             continue
 
-        ts_url = tool.get('tool_shed_url', DEFAULT_TOOL_SHED_URL)
-        if ts_url != DEFAULT_TOOL_SHED_URL:
-            logging.warning('Non-default Tool Shed URL for %s/%s: %s', tool['owner'], tool['name'], ts_url)
-        ts = tool_sheds[ts_url]
+        tool_shed_url = tool.get('tool_shed_url', DEFAULT_TOOL_SHED_URL)
+        if tool_shed_url != DEFAULT_TOOL_SHED_URL:
+            logging.warning('Non-default Tool Shed URL for %s/%s: %s', tool['owner'], tool['name'], tool_shed_url)
 
         logging.info("Fetching updates for {owner}/{name}".format(**tool))
-
         try:
-            revs = ts.repositories.get_ordered_installable_revisions(tool['name'], tool['owner'])
-        except Exception as e:
-            print(e)
+            revisions = get_revisions(tool, stats)
+        except Exception as error:
+            raise RuntimeError('{owner}/{name}: {error}'.format(error=error, **tool)) from error
+
+        if not revisions:
+            raise RuntimeError('Tool Shed returned no revisions for {owner}/{name}'.format(**tool))
+        stats['repositories'] += 1
+        latest_revision = str(revisions[-1])
+        if latest_revision in tool.get('revisions', []):
+            stats['current'] += 1
             continue
 
-        logging.debug('TS revisions: %s' % ','.join(revs))
-        latest_rev = revs[-1]
-        if latest_rev in tool.get('revisions', []):
-            # The rev is already known, don't add again.
-            continue
+        logging.info(
+            "Found newer revision of {owner}/{name} ({revision})".format(revision=latest_revision, **tool)
+        )
+        tool.setdefault('revisions', []).append(latest_revision)
+        stats['updates'] += 1
+        changed = True
 
-        logging.info("Found newer revision of {owner}/{name} ({rev})".format(rev=latest_rev, **tool))
-
-        # Get latest rev, if not already added, add it.
-        if 'revisions' not in tool:
-            tool['revisions'] = []
-
-        if latest_rev not in tool['revisions']:
-            # TS doesn't support utf8 and we don't want to either.
-            tool['revisions'].append(str(latest_rev))
-
-    with open(fn + '.lock', 'w') as handle:
-        yaml.dump(locked, handle, default_flow_style=False)
+    if changed:
+        with open(fn + '.lock', 'w') as handle:
+            yaml.dump(locked, handle, default_flow_style=False)
+        stats['files_written'] += 1
 
 
+def write_summary(stats, files_scanned, started, error=None):
+    summary = '\n'.join([
+        '## Tool Shed update summary',
+        '',
+        '**Status:** {}'.format('failed' if error else 'completed'),
+        '',
+        '- Lockfiles scanned: {}'.format(files_scanned),
+        '- Repositories checked: {}'.format(stats['repositories']),
+        '- Repositories already current: {}'.format(stats['current']),
+        '- Latest revisions found: {}'.format(stats['updates']),
+        '- Files written: {}'.format(stats['files_written']),
+        '- Request attempts: {}'.format(stats['requests']),
+        '- Transient retries: {}'.format(stats['retries']),
+        '- HTTP 429 responses: {}'.format(stats['rate_limits']),
+        '- HTTP 5xx responses: {}'.format(stats['server_errors']),
+        '- Network errors: {}'.format(stats['network_errors']),
+        '- Unresolved failures: {}'.format(1 if error else 0),
+        '- Duration: {:.1f}s'.format(time.monotonic() - started),
+    ])
+    if error:
+        summary += '\n\n- Failure: `{}`'.format(str(error).replace('`', "'"))
+    logging.info('\n%s', summary)
 
-if __name__ == '__main__':
+    if os.environ.get('GITHUB_STEP_SUMMARY'):
+        with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as handle:
+            handle.write(summary + '\n')
+
+
+def main(argv=None):
     parser = argparse.ArgumentParser()
-    parser.add_argument('fn', type=argparse.FileType('r'), help="Tool.yaml file")
+    parser.add_argument('fn', nargs='+', help="Tool.yaml files")
     parser.add_argument('--owner', action='append', help="Repository owner to filter on, anything matching this will be updated. Can be specified multiple times")
     parser.add_argument('--name', help="Repository name to filter on, anything matching this will be updated")
     parser.add_argument('--without', action='store_true', help="If supplied will ignore any owner/name and just automatically add the latest hash for anything lacking one.")
     parser.add_argument('--log', choices=('critical', 'error', 'warning', 'info', 'debug'), default='info')
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     logging.basicConfig(level=getattr(logging, args.log.upper()))
-    update_file(args.fn.name, owner=args.owner, name=args.name, without=args.without)
+    stats = defaultdict(int)
+    started = time.monotonic()
+    files_scanned = 0
+    error = None
+
+    try:
+        for fn in args.fn:
+            files_scanned += 1
+            update_file(fn, owner=args.owner, name=args.name, without=args.without, stats=stats)
+    except Exception as error:
+        logging.error('Tool update failed: %s', error)
+        write_summary(stats, files_scanned, started, error)
+        return 1
+
+    write_summary(stats, files_scanned, started)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_update_tool.py
+++ b/tests/test_update_tool.py
@@ -111,7 +111,7 @@ class UpdateToolTestCase(unittest.TestCase):
             self.assertEqual(tool_shed.repositories.get_ordered_installable_revisions.call_count, 2)
             self.assertEqual(revisions, ['old', 'latest'])
             self.assertIn('Unresolved failures: 1', summary.read_text())
-            self.assertIn('iuc/missing', summary.read_text())
+            self.assertIn('Failure: `iuc/missing: HTTP 404`', summary.read_text())
 
     def test_continues_after_empty_revision_list(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_update_tool.py
+++ b/tests/test_update_tool.py
@@ -113,18 +113,20 @@ class UpdateToolTestCase(unittest.TestCase):
             self.assertIn('Unresolved failures: 1', summary.read_text())
             self.assertIn('Failure: `iuc/missing: HTTP 404`', summary.read_text())
 
-    def test_continues_after_empty_revision_list(self):
-        with tempfile.TemporaryDirectory() as directory:
-            filename = self.write_lockfile(directory)
-            summary = Path(directory) / 'summary.md'
-            self.tool_shed([[]])
+    def test_continues_after_missing_revision_response(self):
+        for revisions in (None, []):
+            with self.subTest(revisions=revisions), tempfile.TemporaryDirectory() as directory:
+                filename = self.write_lockfile(directory)
+                summary = Path(directory) / 'summary.md'
+                self.tool_shed([revisions])
 
-            with mock.patch.dict(os.environ, {'GITHUB_STEP_SUMMARY': str(summary)}):
-                result = update_tool.main([str(filename)])
+                with mock.patch.object(update_tool.time, 'sleep'), \
+                        mock.patch.dict(os.environ, {'GITHUB_STEP_SUMMARY': str(summary)}):
+                    result = update_tool.main([str(filename)])
 
-            self.assertEqual(result, 1)
-            self.assertIn('Unresolved failures: 1', summary.read_text())
-            self.assertIn('Tool Shed returned no revisions for iuc/example', summary.read_text())
+                self.assertEqual(result, 1)
+                self.assertIn('Unresolved failures: 1', summary.read_text())
+                self.assertIn('Tool Shed returned no revisions for iuc/example', summary.read_text())
 
     def test_adds_scheme_before_creating_tool_shed(self):
         factory = mock.Mock()

--- a/tests/test_update_tool.py
+++ b/tests/test_update_tool.py
@@ -73,20 +73,30 @@ class UpdateToolTestCase(unittest.TestCase):
 
     def test_unresolved_failure_exits_nonzero_without_writing(self):
         with tempfile.TemporaryDirectory() as directory:
-            filename = self.write_lockfile(directory)
+            first_directory = Path(directory) / 'first'
+            second_directory = Path(directory) / 'second'
+            first_directory.mkdir()
+            second_directory.mkdir()
+            first = self.write_lockfile(first_directory)
+            second = self.write_lockfile(second_directory, name='unreached')
             summary = Path(directory) / 'summary.md'
             error = ConnectionError('rate limited', status_code=429)
-            self.tool_shed([error] * update_tool.MAX_ATTEMPTS)
+            tool_shed = self.tool_shed([error] * update_tool.MAX_ATTEMPTS)
 
             with mock.patch.object(update_tool.time, 'sleep'), \
                     mock.patch.dict(os.environ, {'GITHUB_STEP_SUMMARY': str(summary)}):
-                result = update_tool.main([str(filename)])
+                result = update_tool.main([str(first), str(second)])
 
-            with open(str(filename) + '.lock') as handle:
-                revisions = yaml.safe_load(handle)['tools'][0]['revisions']
             self.assertEqual(result, 1)
-            self.assertEqual(revisions, ['old'])
+            self.assertEqual(
+                tool_shed.repositories.get_ordered_installable_revisions.call_count,
+                update_tool.MAX_ATTEMPTS,
+            )
+            for filename in (first, second):
+                with open(str(filename) + '.lock') as handle:
+                    self.assertEqual(yaml.safe_load(handle)['tools'][0]['revisions'], ['old'])
             self.assertIn('**Status:** failed', summary.read_text())
+            self.assertIn('Lockfiles scanned: 1', summary.read_text())
             self.assertIn('HTTP 429 responses: {}'.format(update_tool.MAX_ATTEMPTS), summary.read_text())
 
     def test_continues_after_not_found_and_exits_nonzero(self):

--- a/tests/test_update_tool.py
+++ b/tests/test_update_tool.py
@@ -46,16 +46,15 @@ class UpdateToolTestCase(unittest.TestCase):
 
         for error in errors:
             with self.subTest(error=error):
-                tool_shed = self.tool_shed([error, ['latest']])
-                stats = defaultdict(int)
-                with mock.patch.object(update_tool.time, 'sleep'):
-                    revisions = update_tool.get_revisions({
-                        'name': 'example',
-                        'owner': 'iuc',
-                    }, stats)
-                self.assertEqual(revisions, ['latest'])
-                self.assertEqual(tool_shed.repositories.get_ordered_installable_revisions.call_count, 2)
-                self.assertEqual(stats['retries'], 1)
+                with tempfile.TemporaryDirectory() as directory:
+                    filename = self.write_lockfile(directory)
+                    tool_shed = self.tool_shed([error, ['old']])
+                    stats = defaultdict(int)
+                    update_tool.last_request_at = 0
+                    with mock.patch.object(update_tool.time, 'sleep'):
+                        update_tool.update_file(str(filename), stats=stats)
+                    self.assertEqual(tool_shed.repositories.get_ordered_installable_revisions.call_count, 2)
+                    self.assertEqual(stats['retries'], 1)
 
     def test_adds_only_latest_revision_and_writes_summary(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_update_tool.py
+++ b/tests/test_update_tool.py
@@ -1,0 +1,95 @@
+import os
+import sys
+import tempfile
+import unittest
+from collections import defaultdict
+from pathlib import Path
+from unittest import mock
+
+import requests
+import yaml
+from bioblend.galaxy.client import ConnectionError
+
+sys.path.insert(0, str(Path(__file__).parents[1] / 'scripts'))
+import update_tool
+
+
+class UpdateToolTestCase(unittest.TestCase):
+    def setUp(self):
+        update_tool.tool_sheds.clear()
+        update_tool.last_request_at = 0
+
+    def tool_shed(self, side_effect):
+        tool_shed = mock.Mock()
+        tool_shed.repositories.get_ordered_installable_revisions.side_effect = side_effect
+        update_tool.tool_sheds[update_tool.DEFAULT_TOOL_SHED_URL] = tool_shed
+        return tool_shed
+
+    def write_lockfile(self, directory):
+        filename = Path(directory) / 'tools.yml'
+        with open(str(filename) + '.lock', 'w') as handle:
+            yaml.safe_dump({
+                'tools': [{
+                    'name': 'example',
+                    'owner': 'iuc',
+                    'revisions': ['old'],
+                }],
+            }, handle)
+        return filename
+
+    def test_retries_transient_errors(self):
+        errors = [
+            ConnectionError('rate limited', status_code=429),
+            ConnectionError('unavailable', status_code=503),
+            requests.ConnectionError('connection failed'),
+        ]
+
+        for error in errors:
+            with self.subTest(error=error):
+                tool_shed = self.tool_shed([error, ['latest']])
+                stats = defaultdict(int)
+                with mock.patch.object(update_tool.time, 'sleep'):
+                    revisions = update_tool.get_revisions({
+                        'name': 'example',
+                        'owner': 'iuc',
+                    }, stats)
+                self.assertEqual(revisions, ['latest'])
+                self.assertEqual(tool_shed.repositories.get_ordered_installable_revisions.call_count, 2)
+                self.assertEqual(stats['retries'], 1)
+
+    def test_adds_only_latest_revision_and_writes_summary(self):
+        with tempfile.TemporaryDirectory() as directory:
+            filename = self.write_lockfile(directory)
+            summary = Path(directory) / 'summary.md'
+            self.tool_shed([['old', 'intermediate', 'latest']])
+
+            with mock.patch.dict(os.environ, {'GITHUB_STEP_SUMMARY': str(summary)}):
+                result = update_tool.main([str(filename)])
+
+            with open(str(filename) + '.lock') as handle:
+                revisions = yaml.safe_load(handle)['tools'][0]['revisions']
+            self.assertEqual(result, 0)
+            self.assertEqual(revisions, ['old', 'latest'])
+            self.assertIn('Latest revisions found: 1', summary.read_text())
+
+    def test_unresolved_failure_exits_nonzero_without_writing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            filename = self.write_lockfile(directory)
+            summary = Path(directory) / 'summary.md'
+            error = ConnectionError('rate limited', status_code=429)
+            self.tool_shed([error] * update_tool.MAX_ATTEMPTS)
+
+            with mock.patch.object(update_tool.time, 'sleep'), \
+                    mock.patch.dict(os.environ, {'GITHUB_STEP_SUMMARY': str(summary)}):
+                result = update_tool.main([str(filename)])
+
+            with open(str(filename) + '.lock') as handle:
+                revisions = yaml.safe_load(handle)['tools'][0]['revisions']
+            self.assertEqual(result, 1)
+            self.assertEqual(revisions, ['old'])
+            self.assertIn('**Status:** failed', summary.read_text())
+            self.assertIn('HTTP 429 responses: 6', summary.read_text())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_update_tool.py
+++ b/tests/test_update_tool.py
@@ -25,12 +25,12 @@ class UpdateToolTestCase(unittest.TestCase):
         update_tool.tool_sheds[update_tool.DEFAULT_TOOL_SHED_URL] = tool_shed
         return tool_shed
 
-    def write_lockfile(self, directory):
+    def write_lockfile(self, directory, name='example'):
         filename = Path(directory) / 'tools.yml'
         with open(str(filename) + '.lock', 'w') as handle:
             yaml.safe_dump({
                 'tools': [{
-                    'name': 'example',
+                    'name': name,
                     'owner': 'iuc',
                     'revisions': ['old'],
                 }],
@@ -87,7 +87,55 @@ class UpdateToolTestCase(unittest.TestCase):
             self.assertEqual(result, 1)
             self.assertEqual(revisions, ['old'])
             self.assertIn('**Status:** failed', summary.read_text())
-            self.assertIn('HTTP 429 responses: 6', summary.read_text())
+            self.assertIn('HTTP 429 responses: {}'.format(update_tool.MAX_ATTEMPTS), summary.read_text())
+
+    def test_continues_after_not_found_and_exits_nonzero(self):
+        with tempfile.TemporaryDirectory() as directory:
+            first_directory = Path(directory) / 'first'
+            second_directory = Path(directory) / 'second'
+            first_directory.mkdir()
+            second_directory.mkdir()
+            first = self.write_lockfile(first_directory, name='missing')
+            second = self.write_lockfile(second_directory)
+            summary = Path(directory) / 'summary.md'
+            error = ConnectionError('not found', status_code=404)
+            tool_shed = self.tool_shed([error, ['old', 'latest']])
+
+            with mock.patch.object(update_tool.time, 'sleep'), \
+                    mock.patch.dict(os.environ, {'GITHUB_STEP_SUMMARY': str(summary)}):
+                result = update_tool.main([str(first), str(second)])
+
+            with open(str(second) + '.lock') as handle:
+                revisions = yaml.safe_load(handle)['tools'][0]['revisions']
+            self.assertEqual(result, 1)
+            self.assertEqual(tool_shed.repositories.get_ordered_installable_revisions.call_count, 2)
+            self.assertEqual(revisions, ['old', 'latest'])
+            self.assertIn('Unresolved failures: 1', summary.read_text())
+            self.assertIn('iuc/missing', summary.read_text())
+
+    def test_continues_after_empty_revision_list(self):
+        with tempfile.TemporaryDirectory() as directory:
+            filename = self.write_lockfile(directory)
+            summary = Path(directory) / 'summary.md'
+            self.tool_shed([[]])
+
+            with mock.patch.dict(os.environ, {'GITHUB_STEP_SUMMARY': str(summary)}):
+                result = update_tool.main([str(filename)])
+
+            self.assertEqual(result, 1)
+            self.assertIn('Unresolved failures: 1', summary.read_text())
+            self.assertIn('Tool Shed returned no revisions for iuc/example', summary.read_text())
+
+    def test_adds_scheme_before_creating_tool_shed(self):
+        factory = mock.Mock()
+        tool_shed = factory.return_value
+
+        with mock.patch.object(update_tool.ToolSheds, 'default_factory', factory):
+            sheds = update_tool.ToolSheds()
+            self.assertIs(sheds['testtoolshed.g2.bx.psu.edu'], tool_shed)
+
+        factory.assert_called_once_with(url='https://testtoolshed.g2.bx.psu.edu')
+        self.assertEqual(tool_shed.timeout, 30)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Serialize and rate-limit Tool Shed lookups, with bounded retries for transient failures.
- Fail incomplete runs and publish a concise Actions summary.
- Continue past per-repository 404 or empty results while reporting them, with focused tests.

## Motivation

PR #1633 missed 77 current revisions after Tool Shed 429 responses were silently ignored. This prevents incomplete automated update PRs from appearing successful.

## Testing

- python3.11 -m unittest discover -s tests -v
- Fork Actions: test and check-fix