### PR TITLE
Update samestr data manager on test.galaxyproject.org

### DIFF
--- a/test.galaxyproject.org/data_managers.yml.lock
+++ b/test.galaxyproject.org/data_managers.yml.lock
@@ -173,6 +173,7 @@ tools:
   revisions:
   - e8873a70f416
   - 405af1001762
+  - f444a2898944
   tool_panel_section_id: data_managers
   tool_panel_section_label: Data Managers
 - name: data_manager_motus


### PR DESCRIPTION
Adds revision `f444a2898944` for `iuc/data_manager_samestr` in `test.galaxyproject.org/data_managers.yml.lock`.

Generated with `scripts/update_tool.py --name data_manager_samestr test.galaxyproject.org/data_managers.yml`.