### PR TITLE
Install data_manager_motus 3.1.0+galaxy2 on test.galaxyproject.org

### DIFF
--- a/test.galaxyproject.org/data_managers.yml.lock
+++ b/test.galaxyproject.org/data_managers.yml.lock
@@ -181,5 +181,6 @@ tools:
   revisions:
   - c153e8dd94ad
   - 603939ba21ec
+  - 27bce4678358
   tool_panel_section_id: data_managers
   tool_panel_section_label: Data Managers


### PR DESCRIPTION
Adds toolshed revision `27bce4678358` (bgruening/data_manager_motus) to the test.galaxyproject.org lockfile via the trusted-update path (`scripts/update_tool.py --name data_manager_motus`).

galaxy2 ([galaxytools#1942](https://github.com/bgruening/galaxytools/pull/1942)) makes the mOTUs DB identifier deterministic (defaults to `db_from_<Zenodo publication date>` instead of the build's wall-clock time) and adds a `--value` override, so the idc reference-data build can pin the value to match the existing entry on usegalaxy.eu (`db_from_2026-04-27T094930Z`).