### PR TITLE
Update PhysiCell Studio to 0.15 on Test

### DIFF
--- a/test.galaxyproject.org/interactive_tools.yml.lock
+++ b/test.galaxyproject.org/interactive_tools.yml.lock
@@ -31,6 +31,7 @@ tools:
   - e88709ce8e25
   - d302ce0877f7
   - 0c714c99cdd3
+  - 80cda66cf1d2
   tool_panel_section_id: interactive_tools
   tool_panel_section_label: Interactive Tools
   tool_shed_url: testtoolshed.g2.bx.psu.edu


### PR DESCRIPTION
Update the Test Tool Shed installation of `rheiland/physicell_studio` on `test.galaxyproject.org` to revision `80cda66cf1d2`.

The Test Tool Shed reports this revision as PhysiCell Studio `0.15`; it is downloadable, non-malicious, and has test components. Source YAML schema validation, live revision metadata validation, and `git diff --check` passed.

## Installation sequence for `tool-installers`
- [x] Test using `@galaxybot test this`
- [x] Inspect CI output for expected changes
- [x] Deploy using `@galaxybot deploy this` if test install was successful
- [x] Merge this PR