### PR TITLE
Install PhysiCell Studio 0.16 on Test

### DIFF
--- a/test.galaxyproject.org/interactive_tools.yml.lock
+++ b/test.galaxyproject.org/interactive_tools.yml.lock
@@ -29,9 +29,10 @@ tools:
   - 500882207f95
   - 0d215c8381c4
   - e88709ce8e25
-  - 80cda66cf1d2
   - d302ce0877f7
   - 0c714c99cdd3
+  - 80cda66cf1d2
+  - 49c094e5e42d
   tool_panel_section_id: interactive_tools
   tool_panel_section_label: Interactive Tools
   tool_shed_url: testtoolshed.g2.bx.psu.edu

--- a/test.galaxyproject.org/interactive_tools.yml.lock
+++ b/test.galaxyproject.org/interactive_tools.yml.lock
@@ -29,9 +29,9 @@ tools:
   - 500882207f95
   - 0d215c8381c4
   - e88709ce8e25
+  - 80cda66cf1d2
   - d302ce0877f7
   - 0c714c99cdd3
-  - 80cda66cf1d2
   tool_panel_section_id: interactive_tools
   tool_panel_section_label: Interactive Tools
   tool_shed_url: testtoolshed.g2.bx.psu.edu


### PR DESCRIPTION
Install the latest Test Tool Shed revision `49c094e5e42d` of `rheiland/physicell_studio` on `test.galaxyproject.org`.

The Test Tool Shed reports this revision as PhysiCell Studio `0.16`; it is downloadable, non-malicious, and has test components. Source YAML schema validation, live latest-revision metadata validation, and `git diff --check` passed.

## Installation sequence for `tool-installers`
- [x] Test using `@galaxybot test this`
- [x] Inspect CI output for expected changes
- [x] Deploy using `@galaxybot deploy this` after successful test install
- [x] Merge this PR