### PR TITLE
Add kegalign revision 592d6682f49b to the Mapping section

### DIFF
--- a/usegalaxy.org/mapping.yml.lock
+++ b/usegalaxy.org/mapping.yml.lock
@@ -192,6 +192,7 @@ tools:
   - 090cbf2cb339
   - 371e4e21d5de
   - 544ea81a6914
+  - 592d6682f49b
   - a7b120f452f2
   - aa0abf2d2722
   - c05177db395f


### PR DESCRIPTION
592d6682f49b is the newest installable revision of richard-burhans/kegalign on the main ToolShed. The tool version is unchanged at 0.2.1.13; the wrapper's VERSION_SUFFIX goes 0 -> 1, so it installs as 0.2.1.13+galaxy1.

IT FIXES A TOOL THAT IS CURRENTLY BROKEN ON usegalaxy.org. The wrapper built its 2bit inputs with `faToTwoBit <(gzip -cdfq ...)`. Process substitution is a bashism and the job script is not guaranteed to run under bash: on the vgp destination the container's /bin/sh rejects it with `syntax error: unexpected "("` and the tool exits 2 before reading a single base. The line had been carried unchanged since 2024-08-29 and every other container tolerated it, so this is a latent bashism finally meeting a POSIX shell rather than a regression in the aligner.

The replacement decompresses to a real file before converting, rather than a FIFO or /dev/stdin, so nothing depends on faToTwoBit accepting a non-seekable input, and removes the uncompressed copy immediately after conversion so it does not sit beside the 2bit files for the life of the job.

Generated with the repo's own tooling rather than by hand:

    python scripts/update_tool.py --owner richard-burhans --name kegalign \
        usegalaxy.org/mapping.yml
    python scripts/fix_lockfile.py usegalaxy.org/mapping.yml

TODO: Please replace this header with a description of your pull request.

## Installation sequence for `tool-installers`
- [x] Test using `@galaxybot test this`
- [ ] Inspect CI output for expected changes
- [ ] Deploy using `@galaxybot deploy this` if test install was successful
- [ ] Merge this PR
