### PR TITLE
Post-GHA-migration cleanup

### DIFF
--- a/.ci/github-actions.sh
+++ b/.ci/github-actions.sh
@@ -32,12 +32,6 @@ GALAXY_DOCKER_IMAGE='galaxy/galaxy-min:dev'
 # Disable if using a locally built image e.g. for debugging
 GALAXY_DOCKER_IMAGE_PULL=true
 
-#GALAXY_TEMPLATE_DB_URL='https://raw.githubusercontent.com/davebx/galaxyproject-sqlite/master/20.01.sqlite'
-#GALAXY_TEMPLATE_DB="${GALAXY_TEMPLATE_DB_URL##*/}"
-# Unset to use create_db.py, which is fast now that it doesn't migrate new DBs
-GALAXY_TEMPLATE_DB_URL=
-GALAXY_TEMPLATE_DB='galaxy.sqlite'
-
 # Set by Actions, so the defaults here are for development
 GIT_COMMIT="${GITHUB_SHA:-$(git rev-parse HEAD)}"
 # GITHUB_RUN_ID is stable across re-runs, while GITHUB_RUN_ATTEMPT increments for each attempt.
@@ -511,16 +505,9 @@ function prep_for_galaxy_run() {
     # Sets globals $GALAXY_DATABASE_TMPDIR $WORKDIR
     log "Copying configs to Stratum 0"
     WORKDIR=$(exec_on mktemp -d -t usegalaxy-tools.work.XXXXXX)
-    if [ -n "$GALAXY_TEMPLATE_DB_URL" ]; then
-        log_exec curl -o ".ci/${GALAXY_TEMPLATE_DB}" "$GALAXY_TEMPLATE_DB_URL"
-        copy_to ".ci/${GALAXY_TEMPLATE_DB}"
-    fi
     copy_to ".ci/tool_sheds_conf.xml"
     copy_to ".ci/condarc"
     GALAXY_DATABASE_TMPDIR=$(exec_on mktemp -d -t usegalaxy-tools.database.XXXXXX)
-    if [ -n "$GALAXY_TEMPLATE_DB_URL" ]; then
-        exec_on mv "${WORKDIR}/${GALAXY_TEMPLATE_DB}" "${GALAXY_DATABASE_TMPDIR}"
-    fi
     if $GALAXY_DOCKER_IMAGE_PULL; then
         log "Fetching latest Galaxy image"
         exec_on docker pull "$GALAXY_DOCKER_IMAGE"
@@ -588,19 +575,9 @@ function run_mounted_galaxy() {
     exec_on docker exec --user "${USER_UID}:${USER_GID}" --workdir /galaxy/server -e "HOME=/galaxy/server/database" "$PRECONFIGURE_CONTAINER_NAME" ./.venv/bin/pip install -r requirements.txt
     commit_preconfigured_container
 
-    if [ -n "$GALAXY_TEMPLATE_DB_URL" ]; then
-        log "Updating database"
-        exec_on docker run --rm --label "$DOCKER_RUN_LABEL" --user "${USER_UID}:${USER_GID}" --name="${CONTAINER_NAME}-setup" \
-            -e "GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION=sqlite:////galaxy/server/database/${GALAXY_TEMPLATE_DB}" \
-            -v "${GALAXY_SOURCE_TMPDIR}:/galaxy/server" \
-            -v "${GALAXY_DATABASE_TMPDIR}:/galaxy/server/database" \
-            --workdir /galaxy/server \
-            "$GALAXY_DOCKER_IMAGE" ./.venv/bin/python ./scripts/manage_db.py upgrade
-    fi
-
     log "Starting Galaxy on Stratum 0"
     exec_on docker run -d --label "$DOCKER_RUN_LABEL" -p 127.0.0.1:${REMOTE_PORT}:8080 --user "${USER_UID}:${USER_GID}" --name="${CONTAINER_NAME}" \
-        -e "GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION=sqlite:////galaxy/server/database/${GALAXY_TEMPLATE_DB}" \
+        -e "GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION=sqlite:////galaxy/server/database/galaxy.sqlite" \
         -e "GALAXY_CONFIG_OVERRIDE_INTEGRATED_TOOL_PANEL_CONFIG=/tmp/integrated_tool_panel.xml" \
         -e "GALAXY_CONFIG_OVERRIDE_SHED_TOOL_CONFIG_FILE=${SHED_TOOL_CONFIG}" \
         -e "GALAXY_CONFIG_OVERRIDE_MIGRATED_TOOLS_CONFIG=/abcdef" \
@@ -628,18 +605,10 @@ function run_cloudve_galaxy() {
 
     patch_cloudve_galaxy
 
-    if [ -n "$GALAXY_TEMPLATE_DB_URL" ]; then
-        log "Updating database"
-        exec_on docker run --rm --label "$DOCKER_RUN_LABEL" --user "${USER_UID}:${USER_GID}" --name="${CONTAINER_NAME}-setup" \
-            -e "GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION=sqlite:////galaxy/server/database/${GALAXY_TEMPLATE_DB}" \
-            -v "${GALAXY_DATABASE_TMPDIR}:/galaxy/server/database" \
-            "$GALAXY_DOCKER_IMAGE" ./.venv/bin/python ./scripts/manage_db.py upgrade
-    fi
-
     # we could just start the patch container and run Galaxy in it with `docker exec`, but then logs aren't captured
     log "Starting Galaxy on Stratum 0"
     exec_on docker run -d --label "$DOCKER_RUN_LABEL" -p 127.0.0.1:${REMOTE_PORT}:8080 --user "${USER_UID}:${USER_GID}" --name="${CONTAINER_NAME}" \
-        -e "GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION=sqlite:////galaxy/server/database/${GALAXY_TEMPLATE_DB}" \
+        -e "GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION=sqlite:////galaxy/server/database/galaxy.sqlite" \
         -e "GALAXY_CONFIG_OVERRIDE_INTEGRATED_TOOL_PANEL_CONFIG=/tmp/integrated_tool_panel.xml" \
         -e "GALAXY_CONFIG_OVERRIDE_SHED_TOOL_CONFIG_FILE=${SHED_TOOL_CONFIG}" \
         -e "GALAXY_CONFIG_OVERRIDE_MIGRATED_TOOLS_CONFIG=/abcdef" \
@@ -777,16 +746,6 @@ function install_tools() {
             show_paths
             log_exit_error "Terminating build due to previous errors"
         }
-        #shed-tools install -v -a deadbeef -t "$tool_yaml" --test --test_json "${tool_yaml##*/}"-test.json || {
-        #    # TODO: test here if test failures should be ignored (but we can't separate test failures from install
-        #    # failures at the moment) and also we can't easily get the job stderr
-        #    [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ] || {
-        #        log_error "Tool install/test failed";
-        #        show_logs
-        #        show_paths
-        #        log_exit_error "Terminating build due to previous errors"
-        #    };
-        #}
     done
 }
 

--- a/.ci/github-actions.sh
+++ b/.ci/github-actions.sh
@@ -12,8 +12,8 @@ set -euo pipefail
 : ${PUBLISH:=false}
 
 # Range passed to `git diff` to detect changed tool files. The default is for running by hand on a PR branch; the
-# workflows pass an explicit range, since after a merge there is nothing left to diff against origin/master.
-: ${COMMIT_RANGE:=origin/master...}
+# workflows pass an explicit range, since after a merge there is nothing left to diff against origin/main.
+: ${COMMIT_RANGE:=origin/main...}
 
 # Scratch space for the per-run overlayfs and CVMFS mounts. Must NOT be $GITHUB_WORKSPACE: that is the git checkout,
 # and creating the overlay dirs inside it would pollute the working tree that detect_changes diffs.

--- a/.github/workflows/check-fix.yml
+++ b/.github/workflows/check-fix.yml
@@ -2,7 +2,8 @@ name: Check make fix
 
 on:
   pull_request:
-    branches: ["master"]
+    # "master" is transitional; drop it once the default branch is renamed.
+    branches: ["master", "main"]
 
 jobs:
   check-fix:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
-# Install changed tools and publish them to CVMFS, on merge of a PR to master. Success or failure is reported back as
-# a comment on the merged PR, since by then nobody is watching the PR's checks.
+# Install changed tools and publish them to CVMFS, on merge of a PR to the default branch. Success or failure is
+# reported back as a comment on the merged PR, since by then nobody is watching the PR's checks.
 #
 # Retry a failed deploy with Actions -> Deploy tools to CVMFS -> the failed run -> "Re-run failed jobs".
 name: Deploy tools to CVMFS
@@ -15,7 +15,8 @@ name: Deploy tools to CVMFS
 on:
   pull_request_target:
     types: [closed]
-    branches: ["master"]
+    # "master" is transitional; drop it once the default branch is renamed.
+    branches: ["master", "main"]
     paths:
       - 'usegalaxy.org/**'
       - 'test.galaxyproject.org/**'
@@ -78,7 +79,8 @@ jobs:
       - name: Install and publish tools
         env:
           PUBLISH: 'true'
-          # The merge commit's first parent is master immediately before the merge, so this is the PR's net change.
+          # The merge commit's first parent is the default branch immediately before the merge, so this is the
+          # PR's net change.
           # Correct for both merge commits and squashes; rebase merging must stay disabled for it to hold.
           COMMIT_RANGE: ${{ github.event.pull_request.merge_commit_sha }}^1...${{ github.event.pull_request.merge_commit_sha }}
         run: .ci/github-actions.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,8 @@ jobs:
     runs-on:
       group: cvmfs-publish
       labels: cvmfs
-    # Requests the protected publish environment; its required reviewers are the deployment authorization gate.
+    # Scopes the Stratum 0 key to this job. Merging is the authorization gate; the environment adds no approval
+    # step of its own.
     environment: cvmfs-publish
     timeout-minutes: 180
     steps:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -4,7 +4,8 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["master"]
+    # "master" is transitional; drop it once the default branch is renamed.
+    branches: ["master", "main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -4,7 +4,8 @@ name: Test tool installation
 
 on:
   pull_request:
-    branches: ["master"]
+    # "master" is transitional; drop it once the default branch is renamed.
+    branches: ["master", "main"]
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In the commands below fill the `{server_name}` as appropriate (usegalaxy.org, te
 1. Commit `{server_name}/<repo>.yaml{.lock}`
 1. Create a PR against the default branch of [usegalaxy-tools](https://github.com/galaxyproject/usegalaxy-tools)
     - Use PR labels as appropriate
-    - To aid PR mergers, you can include information on tools in the repo's use of `$GALAXY_SLOTS`, or even PR any needed update(s) to [Main's job_conf.xml](https://github.com/galaxyproject/usegalaxy-playbook/blob/master/env/main/templates/galaxy/config/job_conf.xml.j2) as explained in the "[Determine tool requirements](#determine-tool-requirements)" section once the test installation succeeds (see details below)
+    - To aid PR mergers, you can include information on tools in the repo's use of `$GALAXY_SLOTS`, or even PR any needed update(s) to [Main's TPV tool config](https://github.com/galaxyproject/usegalaxy-playbook/blob/main/env/common/templates/galaxy/config/tpv/tools.yaml.j2) as explained in the "[Determine tool requirements](#determine-tool-requirements)" section once the test installation succeeds (see details below)
 1. Once the PR is merged and the tool appears on [usegalaxy.org](https://usegalaxy.org/) or [test.galaxyproject.org](https://test.galaxyproject.org), test to ensure the tool works.
 
 ## Loading tools in your Galaxy
@@ -108,7 +108,7 @@ Once preconditions are met:
       ```
       Warnings about `[WARNING] 'shed_tools/.../.wh..opq' should be deleted, but was not found in repository.` can be safely ignored.
 5. **If the deploy failed,** retry it with *Actions → Deploy tools to CVMFS →* the failed run *→ Re-run failed jobs*. If that is not possible, deployment can still be re-triggered by making a new PR with whitespace/order changes in the `.lock` file(s) modified in the original PR.
-6. If these are new tools and not just new versions of already installed tools, review whether the tool uses multiple cores (the presence of `${GALAXY_SLOTS:-N}` in `<command>`) and whether increased memory is required and PR changes to the TPV config in https://github.com/galaxyproject/usegalaxy-playbook/
+6. If these are new tools and not just new versions of already installed tools, review whether the tool uses multiple cores (the presence of `${GALAXY_SLOTS:-N}` in `<command>`) and whether increased memory is required and PR changes to [the TPV tool config](https://github.com/galaxyproject/usegalaxy-playbook/blob/main/env/common/templates/galaxy/config/tpv/tools.yaml.j2) in usegalaxy-playbook
 
 Only approved tool installers can install tools. Request admission to the Github Team from project admins for approval.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In the commands below fill the `{server_name}` as appropriate (usegalaxy.org, te
 1. Run `make TOOLSET={server_name} lint`
     - Fix any issue that may arise and `git add` again
 1. Commit `{server_name}/<repo>.yaml{.lock}`
-1. Create a PR against the `master` branch of [usegalaxy-tools](https://github.com/galaxyproject/usegalaxy-tools)
+1. Create a PR against the default branch of [usegalaxy-tools](https://github.com/galaxyproject/usegalaxy-tools)
     - Use PR labels as appropriate
     - To aid PR mergers, you can include information on tools in the repo's use of `$GALAXY_SLOTS`, or even PR any needed update(s) to [Main's job_conf.xml](https://github.com/galaxyproject/usegalaxy-playbook/blob/master/env/main/templates/galaxy/config/job_conf.xml.j2) as explained in the "[Determine tool requirements](#determine-tool-requirements)" section once the test installation succeeds (see details below)
 1. Once the PR is merged and the tool appears on [usegalaxy.org](https://usegalaxy.org/) or [test.galaxyproject.org](https://test.galaxyproject.org), test to ensure the tool works.

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -134,7 +134,7 @@ existing run directory is stale.
   - Add `@galaxyproject/tool-installers` as required reviewers. This is the deploy authorization gate, and it is
     separate from merge permission: approving the merge does not approve the publish. Self-review is allowed, so the
     person who merges can also release the deploy.
-- **Settings → Branches → branch protection for `master`**
+- **Settings → Branches → branch protection for the default branch**
   - Require the `test-install` check to pass before merging. The check always reports, including for PRs without tool
     changes; only its privileged installation dependency is conditional.
   - Require pull requests, with both **Require approvals** and **Require review from Code Owners**. The approval count

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -55,15 +55,17 @@ and `cvmfs_server publish`, and to `rsync` the overlay upper dir across.
   `StrictHostKeyChecking=yes`, so an absent or changed key stops the deploy.
 - **The private key is not stored on the runner.** It lives in the `cvmfs-publish` environment as
   the `STRATUM0_SSH_KEY` secret and is loaded into an `ssh-agent` for the life of the deploy job
-  only. The publish runner group only permits the default-branch deploy workflow, and required environment reviewers
-  provide a separate authorization gate. The agent is killed in an `if: always()` step.
+  only.
 
 ## Runner registration
 
-Create two **organization-level runner groups** that allow only selected workflows:
+Create two **organization-level runner groups**, each visible only to `galaxyproject/usegalaxy-tools`, each with
+*Allow public repositories* and *Restrict to selected workflows* on, and each allowing exactly one workflow:
 
-- `cvmfs-test` allows only `galaxyproject/usegalaxy-tools/.github/workflows/test-install.yml`.
-- `cvmfs-publish` allows only `galaxyproject/usegalaxy-tools/.github/workflows/deploy.yml` from the default branch.
+| group | allowed workflow |
+|---|---|
+| `cvmfs-test` | `galaxyproject/usegalaxy-tools/.github/workflows/test-install.yml` |
+| `cvmfs-publish` | `galaxyproject/usegalaxy-tools/.github/workflows/deploy.yml@refs/heads/main` |
 
 Each group is served by its own host, and no host is ever in both. A just-in-time registration carries exactly the
 labels the hypervisor asks for, and none of the `self-hosted`/`Linux`/`X64` defaults that `config.sh` would add, so
@@ -75,10 +77,8 @@ accept a `pull_request` job.
 ### Runner lifecycle
 
 Neither runner is registered persistently. Each host is a bhyve VM that runs **exactly one job per boot** and then
-powers itself off, and the hypervisor rolls its disk back to a clean snapshot before booting it again. On the test
-host that rollback is what prevents PR-controlled code from persisting into a later run; on the publish host it is not
-load-bearing, but keeping the two identical means there is one operational story rather than two. Provisioning of both
-the guest and hypervisor halves lives in the Ansible playbook, not in this repository.
+powers itself off, and the hypervisor rolls its disk back to a clean snapshot before booting it again. Provisioning of
+both the guest and hypervisor halves lives in the [Ansible playbook][infrastructure-playbook], not in this repository.
 
 One cycle:
 
@@ -87,26 +87,43 @@ One cycle:
    writes the returned config into the VM's `customer_metadata` as `jitconfig`.
 3. It starts the VM. The boot unit reads the config with `mdata-get`, removes it with `mdata-delete`, and execs
    `run.sh --jitconfig`.
-4. The runner takes one job, reports its result, deregisters itself, and exits. Only then does the guest power off, so
-   a job's status always reaches GitHub before the host goes away.
-
-Step 4 is the part worth preserving if any of this is reimplemented. Powering off from a job hook instead would race
-the runner's own completion report, turning successful deploys into red builds — and a deploy that publishes to CVMFS
-and then reports failure is exactly the "expected red build" habit this pipeline exists to eliminate.
+4. The runner takes one job, reports its result, deregisters itself, and exits.
+5. The guest powers off.
 
 Because the registration is generated on the hypervisor, neither VM holds a credential that can register a runner: a
-compromised test host cannot add itself to the publish group. It is also single-use, which is why the guest deletes it
-from metadata before any job code exists — the runner user reaches root through the `docker` group, so anything left
-in metadata is readable by the job.
+compromised test host cannot add itself to the publish group (and it is regardless single-use and consumed before any
+job code runs).
 
 If a rollback fails, the hypervisor leaves the VM stopped rather than starting it dirty, and repeated failed boots
 trip a backoff. Watch for that state: a group with no runner in it does not fail jobs, it queues them silently until
 GitHub cancels them **24 hours** later.
 
+### Hypervisor credential
+
+Minting a registration is the one privileged thing the hypervisor does, and it needs a token for it. That token is a
+**fine-grained personal access token**, currently owned by **@natefoo** — a personal credential doing an
+infrastructure job, which is worth knowing before it becomes a surprise.
+
+| | |
+|---|---|
+| Location | `/opt/custom/etc/gha-runner-cycle.token` on the hypervisor, `root:root`, mode `0600` |
+| Read by | `gha-runner-cycle.sh`, via the Ansible-managed conf beside it |
+| Resource owner | the `galaxyproject` organization |
+| Permission | **Organization permissions → Self-hosted runners → Read and write**, and nothing else |
+
+**Keep it off GitHub.** It must never become a repository or environment secret. A workflow able to read it could
+register a runner into the publish group, which is the boundary the split hosts exist to draw.
+
+**It expires.** Renew it before it does, and record the expiry date somewhere that is watched, because this credential
+fails in the quiet direction: once `generate-jitconfig` returns 401 the cycle script logs the failure and leaves the VM
+stopped, the runner group empties, and jobs queue against nothing until GitHub cancels them 24 hours later. Nothing
+turns red in the meantime. A job sitting in *Waiting for a runner* with an empty runner group is the symptom;
+`gha-runner-cycle.sh`'s log on the hypervisor is where the cause is visible.
+
 ### Job-started hook
 
-The hook lives in the Ansible playbook, not here, and is installed into each golden image — never run it from a
-repository checkout that a PR can modify:
+The hook lives in the [Ansible playbook][infrastructure-playbook], not here, and is installed into each golden image —
+never run it from a repository checkout that a PR can modify:
 
 ```
 ACTIONS_RUNNER_HOOK_JOB_STARTED=/data/actions-runner-hooks/usegalaxy-tools-job-started.sh
@@ -131,9 +148,10 @@ existing run directory is stale.
   - Workflow permissions: read-only by default.
 - **Settings → Environments → `cvmfs-publish`**
   - Secret `STRATUM0_SSH_KEY` — the private key authorized on the Stratum 0 hosts.
-  - Add `@galaxyproject/tool-installers` as required reviewers. This is the deploy authorization gate, and it is
-    separate from merge permission: approving the merge does not approve the publish. Self-review is allowed, so the
-    person who merges can also release the deploy.
+    The environment exists to scope that secret, **not** to add an approval step: merging is the authorization gate,
+    and a second "Approve and deploy" click would only re-confirm a decision the same people made moments earlier.
+    Leave required reviewers unset. Deployment branch policy must stay at *No restriction* — a `pull_request_target`
+    run is `refs/pull/N/merge`, which no branch policy can match.
 - **Settings → Branches → branch protection for the default branch**
   - Require the `test-install` check to pass before merging. The check always reports, including for PRs without tool
     changes; only its privileged installation dependency is conditional.
@@ -146,34 +164,4 @@ existing run directory is stale.
     `<merge_commit_sha>^1...<merge_commit_sha>`, which is correct for merge commits and squashes
     but not for rebase merges, where it would see only the PR's last commit.
 
-## Verifying the runner
-
-Before pointing the real workflows at it, confirm the mount stack works under the runner user with
-a throwaway workflow that does nothing but mount and unmount:
-
-```yaml
-jobs:
-  smoke:
-    runs-on:
-      group: cvmfs-test
-      labels: cvmfs
-    steps:
-      - uses: actions/checkout@v7
-      - run: |
-          set -euo pipefail
-          export REPO_STRATUM0=cvmfs0-psu1.galaxyproject.org
-          export CVMFS_CACHE=/data/actions-runner/cvmfs-cache
-          export CVMFS_SOCKETS=/tmp/smoke/sockets
-          export RUN_DIR=/tmp/smoke
-          mkdir -p /tmp/smoke/{lower,upper,work,mount,sockets}
-          cvmfs2 -o config=.ci/cvmfs-fuse.conf,allow_root test.galaxyproject.org /tmp/smoke/lower
-          fuse-overlayfs -o lowerdir=/tmp/smoke/lower,upperdir=/tmp/smoke/upper,workdir=/tmp/smoke/work,allow_root /tmp/smoke/mount
-          ls /tmp/smoke/mount
-          fusermount -u /tmp/smoke/mount
-          fusermount -u /tmp/smoke/lower
-```
-
-Then open a PR that installs a single small tool on `test.galaxyproject.org` and check that the
-run summary shows the overlay upper contents and the `shed_tool_conf.xml` diff, and that the
-Stratum 0 revision (from `http://<stratum0>/cvmfs/<repo>/.cvmfspublished`) is **unchanged** — the
-test job must never publish.
+[infrastructure-playbook]: https://github.com/galaxyproject/infrastructure-playbook/


### PR DESCRIPTION
Follow-up housekeeping now that tool installs and CVMFS publishing run entirely on GitHub Actions. No behaviour changes to the pipeline.

### Document the runner registration token

The hypervisor mints each JIT runner registration with a **fine-grained PAT belonging to @natefoo**, which was written down nowhere. `docs/self-hosted-runner.md` now records whose it is, that it lives at `/opt/custom/etc/gha-runner-cycle.token` (root-owned, `0600`, never a repository secret), and that the only permission it needs is *Organization permissions → Self-hosted runners → Read and write*.

Worth knowing: **it expires, and it fails quietly.** Once `generate-jitconfig` starts returning 401 the cycle script leaves the VM stopped, the runner group empties, and jobs queue against nothing until GitHub cancels them 24 hours later. Nothing goes red.

### Correct the `cvmfs-publish` environment description

The docs still described required environment reviewers as the deploy authorization gate. That rule has been removed — merging is the gate, and a second "Approve and deploy" click only re-confirms a decision the same people made moments earlier. The environment remains, because scoping `STRATUM0_SSH_KEY` to jobs that declare it is the half that matters. Also noted that a deployment branch policy cannot be used here at all, since a `pull_request_target` run is `refs/pull/N/merge`.

### Prepare for the `master` → `main` rename

Every hardcoded `master` is either replaced or made branch-agnostic. The four workflow filters accept **both** names for now, deliberately: a filter matching neither would stop `test-install` from reporting, which blocks every merge, and stop `deploy` from firing at all. That decouples merging this from doing the rename. Drop `"master"` from the filters afterwards.

One thing a rename does *not* fix, now documented: the `cvmfs-publish` runner group's workflow restriction is stored ref-pinned as `.../deploy.yml@refs/heads/<branch>` and has to be updated by hand.

### Remove dead code from `.ci/github-actions.sh`

- **Galaxy template database.** `GALAXY_TEMPLATE_DB_URL` has been empty for years, so all four `if [ -n ... ]` branches are skipped and the two `manage_db.py upgrade` containers never run. Galaxy creates the sqlite database on startup when it does not exist; the template dated from when a new database was built up through migrations. The surviving connection overrides name `galaxy.sqlite` directly, so this is a no-op at runtime.
- **Commented-out `shed-tools ... --test` block**, guarded by `TRAVIS_PULL_REQUEST` / `TRAVIS_BRANCH` — it predates even Jenkins.

### Point tool requirements at TPV

Per-tool cores and memory live in TPV now, so both README references to Main's `job_conf.xml` now link `env/common/templates/galaxy/config/tpv/tools.yaml.j2`.

---

Jenkins needed no attention here — `.ci/jenkins.sh` and the dead `known_hosts` / `deploy_key.pem.enc` / `default.local` / `*.pub` files are already gone from `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
