### PR TITLE
Drop master branch from workflows

### DIFF
--- a/.github/workflows/check-fix.yml
+++ b/.github/workflows/check-fix.yml
@@ -2,8 +2,7 @@ name: Check make fix
 
 on:
   pull_request:
-    # "master" is transitional; drop it once the default branch is renamed.
-    branches: ["master", "main"]
+    branches: ["main"]
 
 jobs:
   check-fix:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,7 @@ name: Deploy tools to CVMFS
 on:
   pull_request_target:
     types: [closed]
-    # "master" is transitional; drop it once the default branch is renamed.
-    branches: ["master", "main"]
+    branches: ["main"]
     paths:
       - 'usegalaxy.org/**'
       - 'test.galaxyproject.org/**'

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -4,8 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    # "master" is transitional; drop it once the default branch is renamed.
-    branches: ["master", "main"]
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -4,8 +4,7 @@ name: Test tool installation
 
 on:
   pull_request:
-    # "master" is transitional; drop it once the default branch is renamed.
-    branches: ["master", "main"]
+    branches: ["main"]
 
 permissions:
   contents: read

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -59,13 +59,17 @@ and `cvmfs_server publish`, and to `rsync` the overlay upper dir across.
 
 ## Runner registration
 
-Create two **organization-level runner groups**, each visible only to `galaxyproject/usegalaxy-tools`, each with
-*Allow public repositories* and *Restrict to selected workflows* on, and each allowing exactly one workflow:
+Create two **organization-level runner groups**, each visible only to `galaxyproject/usegalaxy-tools` and each with
+*Allow public repositories* on.
 
-| group | allowed workflow |
-|---|---|
-| `cvmfs-test` | `galaxyproject/usegalaxy-tools/.github/workflows/test-install.yml` |
-| `cvmfs-publish` | `galaxyproject/usegalaxy-tools/.github/workflows/deploy.yml@refs/heads/main` |
+On `cvmfs-publish`, also turn on *Restrict to selected workflows* and allow exactly one:
+
+```
+galaxyproject/usegalaxy-tools/.github/workflows/deploy.yml@refs/heads/main
+```
+
+`cvmfs-test` is left unrestricted. A selected workflow must be pinned to a ref, and `test-install.yml` runs on
+`pull_request`, whose runs do not match a branch ref.
 
 Each group is served by its own host, and no host is ever in both. A just-in-time registration carries exactly the
 labels the hypervisor asks for, and none of the `self-hosted`/`Linux`/`X64` defaults that `config.sh` would add, so


### PR DESCRIPTION
And minor doc correction due to GH limitations.

## Installation sequence for `tool-installers`
- [ ] Inspect the automatic *Test tool installation* summary for the expected changes
- [ ] Merge this PR if the test installation succeeded
- [ ] Inspect the post-merge *Deploy tools to CVMFS* summary and bot result comment
