### PR TITLE
Update create-pull-request action to v8

### DIFF
--- a/.github/workflows/update-cloud-repo.yml
+++ b/.github/workflows/update-cloud-repo.yml
@@ -30,7 +30,7 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
             token: ${{ secrets.GITHUB_TOKEN }}
             title: Update cloud repo ${{ steps.date.outputs.date }}

--- a/.github/workflows/update-iwc-tools.yml
+++ b/.github/workflows/update-iwc-tools.yml
@@ -34,7 +34,7 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
             token: ${{ secrets.GITHUB_TOKEN }}
             title: Install IWC tools for ${{ matrix.toolset }} ${{ steps.date.outputs.date }}

--- a/.github/workflows/update-repos.yml
+++ b/.github/workflows/update-repos.yml
@@ -30,7 +30,7 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
             token: ${{ secrets.GITHUB_TOKEN }}
             title: Update all repos ${{ steps.date.outputs.date }}


### PR DESCRIPTION
Update all workflows that create automated pull requests from peter-evans/create-pull-request v6 to v8.

The repository Actions allow-list has also been updated separately to permit peter-evans/create-pull-request@v8.

Validation:
- git diff --check
- YAML parsing for all three changed workflows
- confirmed the upstream v8 tag exists