### PR TITLE
Install PhysiCell Studio 0.17.1 on Test

### DIFF
--- a/test.galaxyproject.org/interactive_tools.yml.lock
+++ b/test.galaxyproject.org/interactive_tools.yml.lock
@@ -33,6 +33,7 @@ tools:
   - 0c714c99cdd3
   - 80cda66cf1d2
   - 49c094e5e42d
+  - 3894802fdbd3
   tool_panel_section_id: interactive_tools
   tool_panel_section_label: Interactive Tools
   tool_shed_url: testtoolshed.g2.bx.psu.edu


### PR DESCRIPTION
Install the latest Test Tool Shed revision `3894802fdbd3` of `rheiland/physicell_studio` on `test.galaxyproject.org`.

The Test Tool Shed reports this revision as PhysiCell Studio `0.17.1`; it is downloadable, non-malicious, and has test components. Source YAML schema validation, live latest-revision metadata validation, and `git diff --check` passed.

The automatic test installation installed only `physicell_studio@3894802fdbd3`, reported zero errored repositories, included the revision in the OverlayFS upper mount, and added the expected `0.17.1` entry to `shed_tool_conf.xml`.

## Installation sequence for `tool-installers`
- [x] Inspect the automatic *Test tool installation* summary for the expected changes
- [x] Merge this PR if the test installation succeeded
- [x] Inspect the post-merge *Deploy tools to CVMFS* summary and bot result comment